### PR TITLE
Fix incorrect reference to lightgallery.js in stimulus-carousel

### DIFF
--- a/_docs/stimulus-carousel.md
+++ b/_docs/stimulus-carousel.md
@@ -70,7 +70,7 @@ With options:
 
 | Attribute | Default | Description | Optional |
 | --------- | ------- | ----------- | -------- |
-| `data-carousel-options-value` | `{}` | Options for lightgallery.js as JSON string. | ✅ |
+| `data-carousel-options-value` | `{}` | Options for swiper.js as JSON string. | ✅ |
 
 ## 🎛 Extending Controller
 


### PR DESCRIPTION
Closes #40 