### PR TITLE
autogrow - allow setting max value; respect row size on connect

### DIFF
--- a/components/textarea-autogrow/src/index.ts
+++ b/components/textarea-autogrow/src/index.ts
@@ -4,20 +4,20 @@ import { debounce } from "../../../utils"
 export default class extends Controller<HTMLInputElement> {
   declare onResize: EventListenerOrEventListenerObject // eslint-disable-line no-undef
   declare resizeDebounceDelayValue: number
+  declare maxHeightValue: number
 
   static values = {
     resizeDebounceDelay: {
       type: Number,
       default: 100,
     },
-  }
-
-  initialize(): void {
-    this.autogrow = this.autogrow.bind(this)
+    maxHeight: {
+      type: Number,
+      default: 15,
+    },
   }
 
   connect(): void {
-    this.element.style.overflow = "hidden"
     const delay: number = this.resizeDebounceDelayValue
 
     this.onResize = delay > 0 ? debounce(this.autogrow, delay) : this.autogrow
@@ -33,7 +33,19 @@ export default class extends Controller<HTMLInputElement> {
   }
 
   autogrow(): void {
-    this.element.style.height = "auto" // Force re-print before calculating the scrollHeight value.
-    this.element.style.height = `${this.element.scrollHeight}px`
+    const textarea = this.element
+    textarea.style.height = 'auto'
+    textarea.style.overflowY = 'hidden'
+
+    const lineHeight = parseFloat(getComputedStyle(textarea).lineHeight)
+    const maxHeight = this.maxHeightValue * lineHeight
+
+    while (textarea.scrollHeight > textarea.offsetHeight && textarea.offsetHeight < maxHeight) {
+      textarea.style.height = `${textarea.offsetHeight + lineHeight}px`
+    }
+
+    if (textarea.offsetHeight >= maxHeight) {
+      textarea.style.overflowY = 'auto'
+    }
   }
 }

--- a/components/textarea-autogrow/src/index.ts
+++ b/components/textarea-autogrow/src/index.ts
@@ -17,7 +17,12 @@ export default class extends Controller<HTMLInputElement> {
     },
   }
 
+  initialize(): void {
+    this.autogrow = this.autogrow.bind(this)
+  }
+
   connect(): void {
+    this.element.style.overflow = 'hidden'
     const delay: number = this.resizeDebounceDelayValue
 
     this.onResize = delay > 0 ? debounce(this.autogrow, delay) : this.autogrow
@@ -37,14 +42,23 @@ export default class extends Controller<HTMLInputElement> {
     textarea.style.height = 'auto'
     textarea.style.overflowY = 'hidden'
 
-    const lineHeight = parseFloat(getComputedStyle(textarea).lineHeight)
-    const maxHeight = this.maxHeightValue * lineHeight
-
-    while (textarea.scrollHeight > textarea.offsetHeight && textarea.offsetHeight < maxHeight) {
-      textarea.style.height = `${textarea.offsetHeight + lineHeight}px`
+    // while textarea scrollHeight > textarea offsetHeight & textarea offsetHeight < this.maxHeightValue (15) rows * height of 1 row
+    while (
+      textarea.scrollHeight > textarea.offsetHeight &&
+      textarea.offsetHeight <
+        this.maxHeightValue * parseFloat(getComputedStyle(textarea).lineHeight)
+    ) {
+      // increase height of textarea by one row
+      textarea.style.height = `${
+        textarea.offsetHeight +
+        parseFloat(getComputedStyle(textarea).lineHeight)
+      }px`
     }
-
-    if (textarea.offsetHeight >= maxHeight) {
+    // if textarea already has > maxHeight rows, activate scroll
+    if (
+      textarea.offsetHeight >=
+      this.maxHeightValue * parseFloat(getComputedStyle(textarea).lineHeight)
+    ) {
       textarea.style.overflowY = 'auto'
     }
   }


### PR DESCRIPTION
I remember spending a lot of time to make autogrow to work nicely.
You can see how it works by trying to post in the [comment section of SupeRails](https://superails.com/posts/avo-internal-tool-rails-8-authentication-invitations-tests)

- [x] add option for max height
- [x] respect textarea `rows="4"` attribute on open

https://github.com/user-attachments/assets/18060f7e-5dfc-4ae5-b1b7-53ae16e10053

