### PR TITLE
Add ability to further nest rails-nested-forms

### DIFF
--- a/components/rails-nested-form/spec/index.test.ts
+++ b/components/rails-nested-form/spec/index.test.ts
@@ -5,61 +5,161 @@
 import { beforeEach, describe, it, expect, vi } from "vitest"
 import { Application } from "@hotwired/stimulus"
 import RailsNestedForm from "../src/index"
-
-const startStimulus = (): void => {
-  const application = Application.start()
-  application.register("nested-form", RailsNestedForm)
-}
+import RailsNestedFormX from "./rails_nested_form_x"
+import RailsNestedFormY from "./rails_nested_form_y"
 
 describe("#nestedForm", (): void => {
-  beforeEach((): void => {
-    startStimulus()
+  describe("with one nesting level", () => {
+    const startStimulus = (): void => {
+      const application = Application.start()
+      application.register("nested-form", RailsNestedForm)
+    }
 
-    document.body.innerHTML = `
-      <form data-controller="nested-form">
-        <template data-nested-form-target="template">
-          <div class="nested-form-wrapper" data-new-record="true">
-            <label for="NEW_RECORD">New todo</label>
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+        <form data-controller="nested-form">
+          <template data-nested-form-target="template">
+            <div class="nested-form-wrapper" data-new-record="true">
+              <label for="NEW_RECORD">New todo</label>
+            </div>
+          </template>
+
+          <div>
+            <label>Your todo</label>
           </div>
-        </template>
 
-        <div>
-          <label>Your todo</label>
-        </div>
+          <div data-nested-form-target="target"></div>
 
-        <div data-nested-form-target="target"></div>
+          <button type="button" data-action="nested-form#add">Add todo</button>
+        </form>
+      `
+    })
 
-        <button type="button" data-action="nested-form#add">Add todo</button>
-      </form>
-    `
+    it("should create new todo", (): void => {
+      const target: HTMLElement = document.querySelector("[data-nested-form-target='target']")
+      const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form#add']")
+
+      expect(target.previousElementSibling.innerHTML).toContain("Your todo")
+
+      addButton.click()
+
+      expect(target.previousElementSibling.innerHTML).toContain("New todo")
+    })
+
+    it("should dispatch events", (): void => {
+      const controllerElement: HTMLButtonElement = document.querySelector("[data-controller='nested-form']")
+      const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form#add']")
+
+      // @ts-expect-error
+      vi.spyOn(global, "CustomEvent").mockImplementation((type: string, eventInit?: any) => ({ type, eventInit }))
+      const mockDispatchEvent = vi.spyOn(controllerElement, "dispatchEvent").mockImplementation(() => true)
+
+      addButton.click()
+
+      expect(mockDispatchEvent).toHaveBeenCalledWith({
+        type: "rails-nested-form:add",
+        eventInit: {
+          bubbles: true,
+        },
+      })
+    })
   })
 
-  it("should create new todo", (): void => {
-    const target: HTMLElement = document.querySelector("[data-nested-form-target='target']")
-    const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form#add']")
+  describe("with two or more nesting levels", () => {
+    const startStimulus = (): void => {
+      const application = Application.start()
+      application.register("nested-form-x", RailsNestedFormX)
+      application.register("nested-form-y", RailsNestedFormY)
+    }
 
-    expect(target.previousElementSibling.innerHTML).toContain("Your todo")
+    beforeEach((): void => {
+      startStimulus()
 
-    addButton.click()
+      document.body.innerHTML = `
+        <form data-controller="nested-form-x">
+          <template data-nested-form-x-target="template">
+            <div class="nested-form-wrapper" data-new-record="true">
+              <label for="campaign_urls_attributes_NEW_RECORD_name">New url</label>
+              <input type="url" name="campaign[urls_attributes][NEW_RECORD][name]" id="campaign_urls_attributes_NEW_RECORD_name">
 
-    expect(target.previousElementSibling.innerHTML).toContain("New todo")
-  })
+              <div data-controller="nested-form-y">
+                <template data-nested-form-y-target="template">
+                  <div class="nested-form-wrapper" data-new-record="true">
+                    <label for="campaign_urls_attributes_NEW_RECORD_keywords_attributes_NEW_RECORD_name">New keyword</label>
+                    <input type="text" name="campaign[urls_attributes][NEW_RECORD][keywords_attributes][NEW_RECORD][name]" id="campaign_urls_attributes_NEW_RECORD_keywords_attributes_NEW_RECORD_name">
+                  </div>
+                </template>
 
-  it("should dispatch events", (): void => {
-    const controllerElement: HTMLButtonElement = document.querySelector("[data-controller='nested-form']")
-    const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form#add']")
+                <div data-nested-form-y-target="target"></div>
 
-    // @ts-expect-error
-    vi.spyOn(global, "CustomEvent").mockImplementation((type: string, eventInit?: any) => ({ type, eventInit }))
-    const mockDispatchEvent = vi.spyOn(controllerElement, "dispatchEvent").mockImplementation(() => true)
+                <button type="button" data-action="nested-form-y#add">Add todo</button>
+              </div>
+            </div>
+          </template>
 
-    addButton.click()
+          <div>
+            <label>Your url</label>
+          </div>
 
-    expect(mockDispatchEvent).toHaveBeenCalledWith({
-      type: "rails-nested-form:add",
-      eventInit: {
-        bubbles: true,
-      },
+          <div data-nested-form-x-target="target"></div>
+
+          <button type="button" data-action="nested-form-x#add">Add url</button>
+        </form>
+      `
+    })
+
+    it("should create new url, not messing with the nested y form", (): void => {
+      const target: HTMLElement = document.querySelector("[data-nested-form-x-target='target']")
+      const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form-x#add']")
+
+      expect(target.previousElementSibling?.innerHTML).toContain("Your url")
+
+      addButton.click()
+
+      // Ensures the timestamp is generated
+      const generatedHtml: String = target.previousElementSibling?.innerHTML || ""
+      const timestampMatch = generatedHtml.match(/campaign_urls_attributes_(\d+)_keywords_attributes_NEW_RECORD_name/)
+      expect(timestampMatch).not.toBeNull()
+
+      const timestamp = timestampMatch ? timestampMatch[1] : ""
+      expect(timestamp).not.toBe("")
+
+      // Check that the timestamp appears for id and for attributes, and is not applied on nested NEW_RECORD
+      expect(
+        (
+          target.previousElementSibling?.innerHTML.match(
+            new RegExp(`campaign_urls_attributes_${timestamp}_keywords_attributes_NEW_RECORD_name`, "g"),
+          ) || []
+        ).length,
+      ).toBe(2)
+
+      // Check that the bracket notation appears once
+      expect(target.previousElementSibling?.innerHTML).toContain(
+        `campaign[urls_attributes][${timestamp}][keywords_attributes][NEW_RECORD][name]`,
+      )
+
+      // Original assertion
+      expect(target.previousElementSibling?.innerHTML).toContain("New url")
+    })
+
+    it("should dispatch events", (): void => {
+      const controllerElement: HTMLButtonElement = document.querySelector("[data-controller='nested-form-x']")
+      const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form-x#add']")
+
+      // @ts-expect-error
+      vi.spyOn(global, "CustomEvent").mockImplementation((type: string, eventInit?: any) => ({ type, eventInit }))
+      const mockDispatchEvent = vi.spyOn(controllerElement, "dispatchEvent").mockImplementation(() => true)
+
+      addButton.click()
+
+      expect(mockDispatchEvent).toHaveBeenCalledWith({
+        type: "rails-nested-form:add",
+        eventInit: {
+          bubbles: true,
+        },
+      })
     })
   })
 })

--- a/components/rails-nested-form/spec/rails_nested_form_x.ts
+++ b/components/rails-nested-form/spec/rails_nested_form_x.ts
@@ -1,0 +1,7 @@
+import RailsNestedForm from "../src/index"
+
+export default class extends RailsNestedForm {
+  connect() {
+    super.connect()
+  }
+}

--- a/components/rails-nested-form/spec/rails_nested_form_y.ts
+++ b/components/rails-nested-form/spec/rails_nested_form_y.ts
@@ -1,0 +1,7 @@
+import RailsNestedForm from "../src/index"
+
+export default class extends RailsNestedForm {
+  connect() {
+    super.connect()
+  }
+}

--- a/components/rails-nested-form/src/index.ts
+++ b/components/rails-nested-form/src/index.ts
@@ -16,7 +16,12 @@ export default class RailsNestedForm extends Controller {
   add(e: Event): void {
     e.preventDefault()
 
-    const content: string = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, new Date().getTime().toString())
+    const content: string = this.templateTarget.innerHTML.replace(
+      /((?:name|id|for)="[^"]*?)NEW_RECORD/g,
+      function (_match, p1) {
+        return p1 + new Date().getTime().toString()
+      },
+    )
     this.targetTarget.insertAdjacentHTML("beforebegin", content)
 
     const event = new CustomEvent("rails-nested-form:add", { bubbles: true })


### PR DESCRIPTION
This feature add the ability to have a rails-nested controller inside a rails-nested controller template. Basically it allows to nest inside another nesting.

I was not able to fix the test issue for the 2nd test. The test passes but it raises an error, anyone has any idea about how to solve this?
```sh
➜  stimulus-components git:(fix-issue-with-nested-in-nested-component) vitest --run

 RUN  v2.1.9 /Users/xxx/stimulus-components

stderr | components/rails-nested-form/spec/index.test.ts > #nestedForm > with two or more nesting levels > should create new url, not messing with the nested y form
Error invoking action "click->nested-form-x#add"

TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.
    at Object.exports.convert (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/generated/Event.js:22:9)
    at HTMLFormElement.dispatchEvent (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:236:24)
    at extended.add (/Users/xxx/stimulus-components/components/rails-nested-form/src/index.ts:28:18)
    at Binding.invokeWithEvent (/Users/xxx/stimulus-components/node_modules/.pnpm/@hotwired+stimulus@3.2.2/node_modules/@hotwired/stimulus/dist/stimulus.umd.js:391:29)
    at Binding.handleEvent (/Users/xxx/stimulus-components/node_modules/.pnpm/@hotwired+stimulus@3.2.2/node_modules/@hotwired/stimulus/dist/stimulus.umd.js:356:22)
    at EventListener.handleEvent (/Users/xxx/stimulus-components/node_modules/.pnpm/@hotwired+stimulus@3.2.2/node_modules/@hotwired/stimulus/dist/stimulus.umd.js:37:29)
    at HTMLButtonElement.callTheUserObjectsOperation (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
    at innerInvokeEventListeners (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
    at invokeEventListeners (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
    at HTMLButtonElementImpl._dispatch (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9) {
  [stack]: "TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.\n" +
    '    at Object.exports.convert (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/generated/Event.js:22:9)\n' +
    '    at HTMLFormElement.dispatchEvent (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:236:24)\n' +
    '    at extended.add (/Users/xxx/stimulus-components/components/rails-nested-form/src/index.ts:28:18)\n' +
    '    at Binding.invokeWithEvent (/Users/xxx/stimulus-components/node_modules/.pnpm/@hotwired+stimulus@3.2.2/node_modules/@hotwired/stimulus/dist/stimulus.umd.js:391:29)\n' +
    '    at Binding.handleEvent (/Users/xxx/stimulus-components/node_modules/.pnpm/@hotwired+stimulus@3.2.2/node_modules/@hotwired/stimulus/dist/stimulus.umd.js:356:22)\n' +
    '    at EventListener.handleEvent (/Users/xxx/stimulus-components/node_modules/.pnpm/@hotwired+stimulus@3.2.2/node_modules/@hotwired/stimulus/dist/stimulus.umd.js:37:29)\n' +
    '    at HTMLButtonElement.callTheUserObjectsOperation (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)\n' +
    '    at innerInvokeEventListeners (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)\n' +
    '    at invokeEventListeners (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)\n' +
    '    at HTMLButtonElementImpl._dispatch (/Users/xxx/stimulus-components/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)',
  [message]: "Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'."
}

{
  identifier: 'nested-form-x',
  controller: <ref *3> extended {
    context: <ref *1> Context {
      logDebugActivity: [Function (anonymous)] { [length]: 1, [name]: '' },
      module: Module {
        application: Application {
          logger: [Console],
          debug: false,
          logDebugActivity: [Function],
          element: [HTMLHtmlElement],
          schema: [Object],
          dispatcher: [Dispatcher],
          router: [Router],
          actionDescriptorFilters: [Object],
          [controllers]: [Getter]
        },
        definition: {
          identifier: 'nested-form-x',
          controllerConstructor: [Function]
        },
        contextsByScope: WeakMap { [Scope] => [Circular *1] },
        connectedContexts: Set(1) { [Circular *1] },
        [identifier]: [Getter],
        [controllerConstructor]: [Getter],
        [contexts]: [Getter]
      },
      scope: <ref *2> Scope {
        targets: TargetSet {
          scope: [Circular *2],
...
 ✓ components/auto-submit/spec/index.test.ts (2)
 ✓ components/character-counter/spec/index.test.ts (2)
 ✓ components/checkbox-select-all/spec/index.test.ts (3)
 ✓ components/confirmation/spec/index.test.ts (6)
 ✓ components/password-visibility/spec/index.test.ts (1)
 ✓ components/rails-nested-form/spec/index.test.ts (4)
 ✓ components/reveal-controller/spec/index.test.ts (1)
 ✓ components/timeago/spec/index.test.ts (5)

 Test Files  8 passed (8)
      Tests  24 passed (24)
   Start at  12:21:24
   Duration  1.53s (transform 534ms, setup 0ms, collect 864ms, tests 717ms, environment 3.99s, prepare 513ms)
```