### PR TITLE
Fix: checkbox-select-all refresh

### DIFF
--- a/components/checkbox-select-all/src/index.ts
+++ b/components/checkbox-select-all/src/index.ts
@@ -55,6 +55,8 @@ export default class CheckboxSelectAll extends Controller {
   }
 
   refresh(): void {
+    if (!this.hasCheckboxAllTarget) return
+
     const checkboxesCount = this.checkboxTargets.length
     const checkboxesCheckedCount = this.checked.length
 


### PR DESCRIPTION
Calling `refresh()` fails when the `checkboxAllTarget` has been removed without disconnecting the host element. We should check for the `hasCheckboxAllTarget`.

This problem occurs, for example, when using page morphing (and having different checkbox groups in old and new HTML).