### PR TITLE
Update Google Places Autocomplete

### DIFF
--- a/components/places-autocomplete/src/index.ts
+++ b/components/places-autocomplete/src/index.ts
@@ -11,7 +11,7 @@ interface Address {
 }
 
 export default class extends Controller {
-  declare autocomplete: google.maps.places.Autocomplete
+  declare autocomplete: google.maps.places.PlaceAutocompleteElement
   declare place: google.maps.places.PlaceResult
 
   declare addressTarget: HTMLInputElement
@@ -65,7 +65,7 @@ export default class extends Controller {
   }
 
   initAutocomplete(): void {
-    this.autocomplete = new google.maps.places.Autocomplete(this.addressTarget, this.autocompleteOptions)
+    this.autocomplete = new google.maps.places.PlaceAutocompleteElement(this.addressTarget, this.autocompleteOptions)
 
     this.autocomplete.addListener("place_changed", this.placeChanged)
   }


### PR DESCRIPTION
fixes #148 

Reference:

https://developers.google.com/maps/documentation/javascript/legacy/places-migration-autocomplete

Browser console error with current version of package:

As of March 1st, 2025, google.maps.places.Autocomplete is not available to new customers. Please use google.maps.places.PlaceAutocompleteElement instead. At this time, google.maps.places.Autocomplete is not scheduled to be discontinued, but google.maps.places.PlaceAutocompleteElement is recommended over google.maps.places.Autocomplete. While google.maps.places.Autocomplete will continue to receive bug fixes for any major regressions, existing bugs in google.maps.places.Autocomplete will not be addressed. At least 12 months notice will be given before support is discontinued. Please see https://developers.google.com/maps/legacy for additional details and https://developers.google.com/maps/documentation/javascript/places-migration-overview for the migration guide.
