### PR TITLE
Allow custom placeholders for deeply nested forms

### DIFF
--- a/components/rails-nested-form/spec/index.test.ts
+++ b/components/rails-nested-form/spec/index.test.ts
@@ -63,3 +63,42 @@ describe("#nestedForm", (): void => {
     })
   })
 })
+
+describe("#deeplyNestedForm", (): void => {
+  beforeEach((): void => {
+    startStimulus()
+
+    document.body.innerHTML = `
+      <form data-controller="nested-form" data-nested-form-new-record-placeholder-value="NEW_OUTER_RECORD">
+        <template data-nested-form-target="template">
+          <div class="nested-form-wrapper" data-new-record="true">
+            <label for="NEW_OUTER_RECORD">New todo</label>
+
+            <div data-controller="nested-form">
+              <div class="nested-form-wrapper" data-new-record="true">
+                <label for="NEW_RECORD">New todo</label>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <div>
+          <label>Your todo</label>
+        </div>
+
+        <div data-nested-form-target="target"></div>
+
+        <button type="button" data-action="nested-form#add">Add todo</button>
+      </form>
+    `
+  })
+
+  it("retains new record placeholder in deeply nested forms", (): void => {
+    const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form#add']")
+    expect(document.querySelector("form[data-controller='nested-form']").innerHTML).toContain("NEW_RECORD")
+
+    addButton.click()
+
+    expect(document.querySelector("div[data-controller='nested-form']").innerHTML).toContain("NEW_RECORD")
+  })
+})

--- a/components/rails-nested-form/spec/index.test.ts
+++ b/components/rails-nested-form/spec/index.test.ts
@@ -2,16 +2,22 @@
  * @jest-environment jsdom
  */
 
-import { beforeEach, describe, it, expect, vi } from "vitest"
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
 import { Application } from "@hotwired/stimulus"
 import RailsNestedForm from "../src/index"
 
+let application: Application
+
 const startStimulus = (): void => {
-  const application = Application.start()
+  application = Application.start()
   application.register("nested-form", RailsNestedForm)
 }
 
 describe("#nestedForm", (): void => {
+  afterEach((): void => {
+    application.stop()
+  })
+
   beforeEach((): void => {
     startStimulus()
 
@@ -64,7 +70,11 @@ describe("#nestedForm", (): void => {
   })
 })
 
-describe("#deeplyNestedForm", (): void => {
+describe("#deeplyNestedForms", (): void => {
+  afterEach((): void => {
+    application.stop()
+  })
+
   beforeEach((): void => {
     startStimulus()
 
@@ -72,33 +82,53 @@ describe("#deeplyNestedForm", (): void => {
       <form data-controller="nested-form" data-nested-form-new-record-placeholder-value="NEW_OUTER_RECORD">
         <template data-nested-form-target="template">
           <div class="nested-form-wrapper" data-new-record="true">
-            <label for="NEW_OUTER_RECORD">New todo</label>
+            <input name="project[NEW_OUTER_RECORD][title]" />
 
             <div data-controller="nested-form">
-              <div class="nested-form-wrapper" data-new-record="true">
-                <label for="NEW_RECORD">New todo</label>
-              </div>
+              <template data-nested-form-target="template">
+                <div class="nested-form-wrapper" data-new-record="true">
+                  <input name="project[NEW_OUTER_RECORD][tasks][NEW_RECORD][title]" />
+                </div>
+              </template>
+              <div data-nested-form-target="target"></div>
+              <button type="button" data-action="nested-form#add">Add task</button>
             </div>
           </div>
         </template>
 
-        <div>
-          <label>Your todo</label>
-        </div>
-
         <div data-nested-form-target="target"></div>
-
-        <button type="button" data-action="nested-form#add">Add todo</button>
+        <button type="button" data-action="nested-form#add">Add project</button>
       </form>
     `
   })
 
-  it("retains new record placeholder in deeply nested forms", (): void => {
-    const addButton: HTMLButtonElement = document.querySelector("[data-action='nested-form#add']")
-    expect(document.querySelector("form[data-controller='nested-form']").innerHTML).toContain("NEW_RECORD")
+  it("should replace outer placeholder but preserve inner placeholder", (): void => {
+    const form = document.querySelector("form[data-controller='nested-form']")
+    const controller = application.getControllerForElementAndIdentifier(form, "nested-form")
 
-    addButton.click()
+    // Mock Date.now() to return a predictable timestamp
+    const mockTimestamp = "1234567890"
+    vi.spyOn(Date.prototype, "getTime").mockReturnValue(parseInt(mockTimestamp))
 
-    expect(document.querySelector("div[data-controller='nested-form']").innerHTML).toContain("NEW_RECORD")
+    // Mock the problematic DOM methods to avoid JSDOM issues
+    const mockInsertAdjacentHTML = vi.fn()
+    const mockDispatchEvent = vi.fn()
+    controller.targetTarget.insertAdjacentHTML = mockInsertAdjacentHTML
+    controller.element.dispatchEvent = mockDispatchEvent
+
+    // Call the add method directly
+    const event = new MouseEvent("click", { bubbles: true })
+    controller.add(event)
+
+    // Verify the replacement logic worked correctly
+    expect(mockInsertAdjacentHTML).toHaveBeenCalledWith(
+      "beforebegin",
+      expect.stringContaining("project[1234567890][title]"),
+    )
+    expect(mockInsertAdjacentHTML).toHaveBeenCalledWith(
+      "beforebegin",
+      expect.stringContaining("project[1234567890][tasks][NEW_RECORD][title]"),
+    )
+    expect(mockInsertAdjacentHTML).toHaveBeenCalledWith("beforebegin", expect.not.stringContaining("NEW_OUTER_RECORD"))
   })
 })

--- a/components/rails-nested-form/src/index.ts
+++ b/components/rails-nested-form/src/index.ts
@@ -4,6 +4,7 @@ export default class RailsNestedForm extends Controller {
   declare targetTarget: HTMLElement
   declare templateTarget: HTMLElement
   declare wrapperSelectorValue: string
+  declare newRecordPlaceholderValue: string
 
   static targets = ["target", "template"]
   static values = {
@@ -11,12 +12,20 @@ export default class RailsNestedForm extends Controller {
       type: String,
       default: ".nested-form-wrapper",
     },
+    newRecordPlaceholder: {
+      type: String,
+      default: "NEW_RECORD",
+    },
   }
 
   add(e: Event): void {
     e.preventDefault()
 
-    const content: string = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, new Date().getTime().toString())
+    // @ts-expect-error
+    const content: string = this.templateTarget.innerHTML.replaceAll(
+      this.newRecordPlaceholderValue,
+      new Date().getTime().toString(),
+    )
     this.targetTarget.insertAdjacentHTML("beforebegin", content)
 
     const event = new CustomEvent("rails-nested-form:add", { bubbles: true })


### PR DESCRIPTION
This would always replace all instances of NEW_RECORD. With this change you you can have diferent placeholders at different levels. For instance When building a survey with pages and fields you can have something like:

```erb
<form data-controller=“nested-form” data-nested-form-new-record-placeholder-value=“NEW_PAGE_RECORD”>
  <!— … ->

  <div data-controller=“nested-form”  data-nested-form-new-record-placeholder-value=“NEW_FIELD_RECORD”>
    <!— … —>
  </div>
</form>
```

This would be an alternative solution to #150 