### PR TITLE
[carousel] update the minimun version for swiper

### DIFF
--- a/components/carousel/package.json
+++ b/components/carousel/package.json
@@ -35,6 +35,6 @@
     "@hotwired/stimulus": "^3"
   },
   "dependencies": {
-    "swiper": "^11.0.6"
+    "swiper": "^12.0.0"
   }
 }


### PR DESCRIPTION

Update the minimun version of swiper for the carousel component. Since the last update, a new version 12 is out. 