### PR TITLE
[Checkbox Select All] Add optional label text support

### DIFF
--- a/components/checkbox-select-all/spec/index.test.ts
+++ b/components/checkbox-select-all/spec/index.test.ts
@@ -5,28 +5,97 @@
 import { beforeEach, describe, it, expect } from "vitest"
 import { Application } from "@hotwired/stimulus"
 import CheckboxSelectAll from "../src/index"
+import { sleep } from "../../../utils"
+
+type CheckboxSelectAllFixtureOptions = {
+  checked?: boolean[]
+  checkboxAllId?: string
+  childCheckboxId?: string
+  disableIndeterminate?: boolean
+  checkedText?: string | null
+  uncheckedText?: string | null
+  withLabel?: boolean
+  labelText?: string
+}
 
 const startStimulus = (): void => {
   const application = Application.start()
   application.register("checkbox-select-all", CheckboxSelectAll)
 }
 
-beforeEach((): void => {
-  startStimulus()
+const waitForStimulus = async (): Promise<void> => {
+  await sleep(0)
+}
+
+const renderCheckboxSelectAllFixture = async ({
+  checked = [false, true, false],
+  checkboxAllId = "checkbox-select-all",
+  childCheckboxId = "checkbox-select-all-child",
+  disableIndeterminate = false,
+  checkedText = null,
+  uncheckedText = null,
+  withLabel = false,
+  labelText = "Select all",
+}: CheckboxSelectAllFixtureOptions = {}): Promise<void> => {
+  const formAttributes = [
+    'data-controller="checkbox-select-all"',
+    disableIndeterminate ? 'data-checkbox-select-all-disable-indeterminate-value="true"' : null,
+    checkedText !== null ? `data-checkbox-select-all-checked-text-value="${checkedText}"` : null,
+    uncheckedText !== null ? `data-checkbox-select-all-unchecked-text-value="${uncheckedText}"` : null,
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  const label = withLabel
+    ? `
+        <label>
+          <input id="${checkboxAllId}" type="checkbox" data-checkbox-select-all-target="checkboxAll" />
+          <span data-checkbox-select-all-target="label">${labelText}</span>
+        </label>
+      `
+    : ""
+
+  const checkboxAll = withLabel
+    ? ""
+    : `<input id="${checkboxAllId}" type="checkbox" data-checkbox-select-all-target="checkboxAll" />`
+
+  const checkboxes = checked
+    .map((isChecked, index) => {
+      const attributes = [
+        'type="checkbox"',
+        'data-checkbox-select-all-target="checkbox"',
+        index === 1 ? `id="${childCheckboxId}"` : null,
+        isChecked ? 'checked="checked"' : null,
+      ]
+        .filter(Boolean)
+        .join(" ")
+
+      return `<input ${attributes} />`
+    })
+    .join("\n")
 
   document.body.innerHTML = `
-    <form data-controller="checkbox-select-all">
-      <input id="checkbox-select-all" type="checkbox" data-checkbox-select-all-target="checkboxAll" />
-      <input type="checkbox" data-checkbox-select-all-target="checkbox" />
-      <input type="checkbox" data-checkbox-select-all-target="checkbox" checked="checked" />
-      <input type="checkbox" data-checkbox-select-all-target="checkbox" />
+    <form ${formAttributes}>
+      ${label || checkboxAll}
+      ${checkboxes}
     </form>
   `
+
+  await waitForStimulus()
+}
+
+beforeEach((): void => {
+  globalThis.Node = window.Node
+  startStimulus()
+})
+
+beforeEach(async (): Promise<void> => {
+  await renderCheckboxSelectAllFixture()
 })
 
 describe("#toggle", () => {
   it("should select all checkboxes", (): void => {
-    const toggleCheckbox: HTMLInputElement = document.querySelector("#checkbox-select-all")
+    const toggleCheckbox = document.querySelector("#checkbox-select-all") as HTMLInputElement
     const targetsBefore: NodeList = document.querySelectorAll("[data-checkbox-select-all-target='checkbox']:checked")
 
     expect(targetsBefore.length).toBe(1)
@@ -45,31 +114,128 @@ describe("#toggle", () => {
 
 describe("#refresh", () => {
   it("change the checkboxAll state", (): void => {
-    const toggleCheckbox: HTMLInputElement = document.querySelector("#checkbox-select-all")
+    const toggleCheckbox = document.querySelector("#checkbox-select-all") as HTMLInputElement
 
     expect(toggleCheckbox.checked).toBe(true)
     expect(toggleCheckbox.indeterminate).toBe(true)
   })
+
+  it("updates the label text on connect", async (): Promise<void> => {
+    await renderCheckboxSelectAllFixture({
+      checkboxAllId: "checkbox-select-all-with-label",
+      checkedText: "Unselect all",
+      uncheckedText: "Select all",
+      withLabel: true,
+      labelText: "Select all",
+    })
+
+    const label = document.querySelector("[data-checkbox-select-all-target='label']") as HTMLElement
+
+    expect(label.textContent).toBe("Unselect all")
+  })
+
+  it("updates the label when toggling select all", async (): Promise<void> => {
+    await renderCheckboxSelectAllFixture({
+      checkboxAllId: "checkbox-select-all-toggle-label",
+      checkedText: "Unselect all",
+      uncheckedText: "Select all",
+      withLabel: true,
+      labelText: "Select all",
+    })
+
+    const toggleCheckbox = document.querySelector("#checkbox-select-all-toggle-label") as HTMLInputElement
+    const label = document.querySelector("[data-checkbox-select-all-target='label']") as HTMLElement
+
+    toggleCheckbox.click()
+    expect(label.textContent).toBe("Select all")
+
+    toggleCheckbox.click()
+    expect(label.textContent).toBe("Unselect all")
+  })
+
+  it("uses checkedText during partial selection in indeterminate mode", async (): Promise<void> => {
+    await renderCheckboxSelectAllFixture({
+      checkboxAllId: "checkbox-select-all-partial-label",
+      checked: [false, false, false],
+      checkedText: "Unselect all",
+      uncheckedText: "Select all",
+      withLabel: true,
+      labelText: "Select all",
+    })
+
+    const checkbox = document.querySelector("#checkbox-select-all-child") as HTMLInputElement
+    const label = document.querySelector("[data-checkbox-select-all-target='label']") as HTMLElement
+
+    checkbox.click()
+
+    expect(label.textContent).toBe("Unselect all")
+  })
+
+  it("does nothing when the label target is absent", (): void => {
+    const toggleCheckbox = document.querySelector("#checkbox-select-all") as HTMLInputElement
+    const checkedBefore = document.querySelectorAll("[data-checkbox-select-all-target='checkbox']:checked")
+    const label = document.querySelector("[data-checkbox-select-all-target='label']")
+
+    expect(checkedBefore).toHaveLength(1)
+    expect(label).toBeNull()
+
+    expect((): void => toggleCheckbox.click()).not.toThrow()
+
+    const checkedAfter = document.querySelectorAll("[data-checkbox-select-all-target='checkbox']:checked")
+
+    expect(checkedAfter).toHaveLength(0)
+  })
+
+  it("does nothing when one of the text values is missing", async (): Promise<void> => {
+    await renderCheckboxSelectAllFixture({
+      checkboxAllId: "checkbox-select-all-missing-value",
+      checkedText: "Unselect all",
+      withLabel: true,
+      labelText: "Original label",
+    })
+
+    const label = document.querySelector("[data-checkbox-select-all-target='label']") as HTMLElement
+
+    expect(label.textContent).toBe("Original label")
+  })
+
+  it("does nothing when the label target is present without text values", async (): Promise<void> => {
+    await renderCheckboxSelectAllFixture({
+      checkboxAllId: "checkbox-select-all-no-text-values",
+      withLabel: true,
+      labelText: "Original label",
+    })
+
+    const label = document.querySelector("[data-checkbox-select-all-target='label']") as HTMLElement
+
+    expect(label.textContent).toBe("Original label")
+  })
 })
 
 describe("when disabled indeterminate state", () => {
-  beforeEach((): void => {
-    startStimulus()
-
-    document.body.innerHTML = `
-    <form data-controller="checkbox-select-all" data-checkbox-select-all-disable-indeterminate-value="true">
-      <input id="checkbox-select-all" type="checkbox" data-checkbox-select-all-target="checkboxAll" />
-      <input type="checkbox" data-checkbox-select-all-target="checkbox" />
-      <input type="checkbox" data-checkbox-select-all-target="checkbox" checked="checked" />
-      <input type="checkbox" data-checkbox-select-all-target="checkbox" />
-    </form>
-  `
+  beforeEach(async (): Promise<void> => {
+    await renderCheckboxSelectAllFixture({ disableIndeterminate: true })
   })
 
   it("change the checkboxAll state", (): void => {
-    const toggleCheckbox: HTMLInputElement = document.querySelector("#checkbox-select-all")
+    const toggleCheckbox = document.querySelector("#checkbox-select-all") as HTMLInputElement
 
     expect(toggleCheckbox.checked).toBe(false)
     expect(toggleCheckbox.indeterminate).toBe(false)
+  })
+
+  it("uses uncheckedText until all boxes are checked when indeterminate is disabled", async (): Promise<void> => {
+    await renderCheckboxSelectAllFixture({
+      checkboxAllId: "checkbox-select-all-disabled-label",
+      disableIndeterminate: true,
+      checkedText: "Unselect all",
+      uncheckedText: "Select all",
+      withLabel: true,
+      labelText: "Select all",
+    })
+
+    const label = document.querySelector("[data-checkbox-select-all-target='label']") as HTMLElement
+
+    expect(label.textContent).toBe("Select all")
   })
 })

--- a/components/checkbox-select-all/src/index.ts
+++ b/components/checkbox-select-all/src/index.ts
@@ -4,20 +4,32 @@ export default class CheckboxSelectAll extends Controller {
   declare readonly hasCheckboxAllTarget: boolean
   declare readonly checkboxTargets: HTMLInputElement[]
   declare readonly checkboxAllTarget: HTMLInputElement
+  declare readonly hasLabelTarget: boolean
+  declare readonly labelTarget: HTMLElement
   declare readonly disableIndeterminateValue: boolean
+  declare readonly hasCheckedTextValue: boolean
+  declare readonly checkedTextValue: string
+  declare readonly hasUncheckedTextValue: boolean
+  declare readonly uncheckedTextValue: string
 
-  static targets = ["checkboxAll", "checkbox"]
+  static targets = ["checkboxAll", "checkbox", "label"]
 
   static values = {
     disableIndeterminate: {
       type: Boolean,
       default: false,
     },
+    checkedText: String,
+    uncheckedText: String,
   }
 
   initialize() {
     this.toggle = this.toggle.bind(this)
     this.refresh = this.refresh.bind(this)
+  }
+
+  connect(): void {
+    this.refresh()
   }
 
   checkboxAllTargetConnected(checkbox: HTMLInputElement): void {
@@ -52,6 +64,8 @@ export default class CheckboxSelectAll extends Controller {
       checkbox.checked = e.target.checked
       this.triggerInputEvent(checkbox)
     })
+
+    this.refresh()
   }
 
   refresh(): void {
@@ -64,6 +78,16 @@ export default class CheckboxSelectAll extends Controller {
       this.checkboxAllTarget.checked = checkboxesCheckedCount > 0
       this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
     }
+
+    this.updateLabel()
+  }
+
+  private updateLabel(): void {
+    if (!this.hasLabelTarget) return
+    if (!this.hasCheckedTextValue) return
+    if (!this.hasUncheckedTextValue) return
+
+    this.labelTarget.textContent = this.checkboxAllTarget.checked ? this.checkedTextValue : this.uncheckedTextValue
   }
 
   triggerInputEvent(checkbox: HTMLInputElement): void {

--- a/docs/components/content/Demo/CheckboxSelectAll.vue
+++ b/docs/components/content/Demo/CheckboxSelectAll.vue
@@ -1,25 +1,35 @@
 <template>
   <Block title="Checkbox Select All">
-    <form data-controller="checkbox-select-all" class="dark:text-gray-300">
+    <form
+      data-controller="checkbox-select-all"
+      data-checkbox-select-all-checked-text-value="Unselect all"
+      data-checkbox-select-all-unchecked-text-value="Select all"
+      class="dark:text-gray-300"
+    >
       <table>
         <tbody>
           <tr>
             <td class="block">
               <label>
                 <input id="checkbox-select-all" type="checkbox" data-checkbox-select-all-target="checkboxAll" />
-                <span class="ml-2">Select All / Deselect All</span>
+                <span data-checkbox-select-all-target="label" class="ml-2">Select all</span>
               </label>
             </td>
 
             <td v-for="index in [...Array(3).keys()]" :key="index" class="block">
               <label>
-                <input type="checkbox" data-checkbox-select-all-target="checkbox" />
+                <input type="checkbox" data-checkbox-select-all-target="checkbox" :checked="index === 1" />
                 <span class="ml-2">Team {{ index + 1 }}</span>
               </label>
             </td>
           </tr>
         </tbody>
       </table>
+
+      <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+        This example opts into the optional label target. Remove the label target and text values to keep the select-all
+        behavior without changing the label text.
+      </p>
     </form>
   </Block>
 </template>

--- a/docs/content/docs/stimulus-checkbox-select-all.md
+++ b/docs/content/docs/stimulus-checkbox-select-all.md
@@ -28,13 +28,17 @@ packagePath: "@stimulus-components/checkbox-select-all"
 ::code-block{tabName="app/views/index.html.erb"}
 
 ```html
-<table data-controller="checkbox-select-all">
+<table
+  data-controller="checkbox-select-all"
+  data-checkbox-select-all-checked-text-value="Unselect all"
+  data-checkbox-select-all-unchecked-text-value="Select all"
+>
   <tbody>
     <tr>
       <td class="block">
         <label>
           <input type="checkbox" data-checkbox-select-all-target="checkboxAll" />
-          <span>Select All / Deselect All</span>
+          <span data-checkbox-select-all-target="label">Select all</span>
         </label>
       </td>
 
@@ -64,6 +68,8 @@ packagePath: "@stimulus-components/checkbox-select-all"
 ```
 
 ::
+
+Add `data-checkbox-select-all-target="label"` plus the two text values only if you want the select-all label to update automatically. If you leave them out, the controller still manages the checkbox state without changing any label text.
 
 ### With Rails
 
@@ -120,10 +126,14 @@ end
 ::code-block{tabName="app/views/index.html"}
 
 ```erb
-<%= form_with model: @user, data: { controller: 'checkbox-select-all' } do |f| %>
+<%= form_with model: @user, data: {
+  controller: 'checkbox-select-all',
+  checkbox_select_all_checked_text_value: 'Unselect all',
+  checkbox_select_all_unchecked_text_value: 'Select all'
+} do |f| %>
   <label>
     <input type="checkbox" data-checkbox-select-all-target="checkboxAll" />
-    <span>Select All / Deselect All</span>
+    <span data-checkbox-select-all-target="label">Select all</span>
   </label>
 
   <%= f.collection_check_boxes :team_ids, Team.all, :id, :name do |b| %>
@@ -139,9 +149,15 @@ end
 
 ## Configuration
 
-| Attribute                                              | Default | Description                      | Optional |
-| ------------------------------------------------------ | ------- | -------------------------------- | -------- |
-| `data-checkbox-select-all-disable-indeterminate-value` | `false` | Disable the indeterminate state. | ✅       |
+| Attribute                                              | Default | Description                                          | Optional |
+| ------------------------------------------------------ | ------- | ---------------------------------------------------- | -------- |
+| `data-checkbox-select-all-disable-indeterminate-value` | `false` | Disable the indeterminate state.                     | ✅       |
+| `data-checkbox-select-all-checked-text-value`          | -       | Text used when the select-all checkbox is checked.   | ✅       |
+| `data-checkbox-select-all-unchecked-text-value`        | -       | Text used when the select-all checkbox is unchecked. | ✅       |
+
+`data-checkbox-select-all-target="label"` is optional and marks the element whose text should change.
+
+In the default indeterminate mode, a partial selection uses the checked label text.
 
 ## Extending Controller
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/7f1dc0db-8366-403a-9c31-329eda7736b9

## Summary

- add optional `label`, `checkedText`, and `uncheckedText` support to `@stimulus-components/checkbox-select-all`
- keep the feature backwards compatible by updating label text only when the target and both values are present
- document and test label behavior for default indeterminate and `disableIndeterminate` modes