### PR TITLE
Remember the visibility of the modal when using the browser's back an…

### DIFF
--- a/components/dialog/CHANGELOG.md
+++ b/components/dialog/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-04-14
+
+### Changed
+
+- Use `openValue` to remember the visibility of the modal when using the browser's back and forward buttons.
+
 ## [1.0.1] - 2024-03-28
 
 ### Changed

--- a/components/dialog/package.json
+++ b/components/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stimulus-components/dialog",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Stimulus controller to show modals with the native Dialog element.",
   "keywords": [
     "stimulus",

--- a/components/dialog/spec/index.test.ts
+++ b/components/dialog/spec/index.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import Dialog from "../src/index"
+
+let application: Application
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("dialog", Dialog)
+}
+
+const flushPromises = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const mockDialogElement = (): void => {
+  Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
+    configurable: true,
+    value: vi.fn(),
+  })
+
+  Object.defineProperty(HTMLDialogElement.prototype, "close", {
+    configurable: true,
+    value: vi.fn(),
+  })
+
+  Object.defineProperty(HTMLDialogElement.prototype, "getAnimations", {
+    configurable: true,
+    value: vi.fn(() => []),
+  })
+
+  Object.defineProperty(HTMLDialogElement.prototype, "removeAttribute", {
+    configurable: true,
+    value: vi.fn(),
+  })
+}
+
+const getDialog = (): HTMLDialogElement => document.querySelector<HTMLDialogElement>("dialog") as HTMLDialogElement
+
+const getController = (): Dialog => {
+  const element = document.querySelector("[data-controller='dialog']") as HTMLElement
+  return application.getControllerForElementAndIdentifier(element, "dialog") as Dialog
+}
+
+beforeEach(() => {
+  mockDialogElement()
+  document.body.innerHTML = ""
+  startStimulus()
+})
+
+afterEach(() => {
+  application.stop()
+  vi.restoreAllMocks()
+})
+
+describe("#connect", () => {
+  it("should open the dialog when open value is true", async () => {
+    document.body.innerHTML = `
+      <div data-controller="dialog" data-dialog-open-value="true">
+        <dialog data-dialog-target="dialog"></dialog>
+      </div>
+    `
+
+    await flushPromises()
+
+    expect(getDialog().showModal).toHaveBeenCalledOnce()
+  })
+
+  it("should not open the dialog when open value is false", async () => {
+    document.body.innerHTML = `
+      <div data-controller="dialog">
+        <dialog data-dialog-target="dialog"></dialog>
+      </div>
+    `
+
+    await flushPromises()
+
+    expect(getDialog().showModal).not.toHaveBeenCalled()
+  })
+})
+
+describe("#open", () => {
+  it("should set open value and show the dialog", async () => {
+    document.body.innerHTML = `
+      <div data-controller="dialog">
+        <dialog data-dialog-target="dialog"></dialog>
+      </div>
+    `
+
+    await flushPromises()
+
+    const controller = getController()
+
+    controller.open()
+
+    expect(controller.openValue).toBe(true)
+    expect(getDialog().showModal).toHaveBeenCalledOnce()
+  })
+})
+
+describe("#close", () => {
+  it("should set closing attribute and close dialog after animations finish", async () => {
+    document.body.innerHTML = `
+      <div data-controller="dialog">
+        <dialog data-dialog-target="dialog"></dialog>
+      </div>
+    `
+
+    await flushPromises()
+
+    const controller = getController()
+    const dialog = getDialog()
+    const finished = Promise.resolve()
+
+    vi.mocked(dialog.getAnimations).mockReturnValue([{ finished } as Animation])
+
+    controller.close()
+
+    expect(controller.openValue).toBe(false)
+    expect(dialog.setAttribute).toBeDefined()
+    expect(dialog.getAttribute("closing")).toBe("")
+
+    await flushPromises()
+
+    expect(dialog.removeAttribute).toHaveBeenCalledWith("closing")
+    expect(dialog.close).toHaveBeenCalledOnce()
+  })
+})
+
+describe("#backdropClose", () => {
+  it("should close the dialog when the event target is the dialog", async () => {
+    document.body.innerHTML = `
+      <div data-controller="dialog">
+        <dialog data-dialog-target="dialog"></dialog>
+      </div>
+    `
+
+    await flushPromises()
+
+    const controller = getController()
+    const closeSpy = vi.spyOn(controller, "close")
+
+    controller.backdropClose({ target: getDialog() } as Event)
+
+    expect(closeSpy).toHaveBeenCalledOnce()
+  })
+
+  it("should not close the dialog when the event target is not the dialog", async () => {
+    document.body.innerHTML = `
+      <div data-controller="dialog">
+        <dialog data-dialog-target="dialog"></dialog>
+      </div>
+    `
+
+    await flushPromises()
+
+    getController().backdropClose(new Event("click", { bubbles: true }))
+
+    expect(getDialog().close).not.toHaveBeenCalled()
+  })
+})
+
+describe("#forceClose", () => {
+  it("should close the dialog", async () => {
+    document.body.innerHTML = `
+      <div data-controller="dialog">
+        <dialog data-dialog-target="dialog"></dialog>
+      </div>
+    `
+
+    await flushPromises()
+
+    getController().forceClose()
+
+    expect(getDialog().close).toHaveBeenCalledOnce()
+  })
+})
+
+describe("turbo:before-render", () => {
+  it("should close the dialog when turbo:before-render is dispatched", async () => {
+    document.body.innerHTML = `
+      <div data-controller="dialog">
+        <dialog data-dialog-target="dialog"></dialog>
+      </div>
+    `
+
+    await flushPromises()
+
+    const dialog = getDialog()
+    const closeSpy = vi.spyOn(dialog, "close")
+
+    document.dispatchEvent(new Event("turbo:before-render"))
+
+    expect(closeSpy).toHaveBeenCalledOnce()
+  })
+})

--- a/components/dialog/src/index.ts
+++ b/components/dialog/src/index.ts
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class Dialog extends Controller {
   declare readonly dialogTarget: HTMLDialogElement
-  declare readonly openValue: boolean
+  declare openValue: boolean
 
   static targets = ["dialog"]
   static values = {
@@ -29,10 +29,12 @@ export default class Dialog extends Controller {
   }
 
   open(): void {
+    this.openValue = true
     this.dialogTarget.showModal()
   }
 
   close(): void {
+    this.openValue = false
     this.dialogTarget.setAttribute("closing", "")
 
     Promise.all(this.dialogTarget.getAnimations().map((animation) => animation.finished)).then(() => {


### PR DESCRIPTION
Now when i go back or forward modal is always visible/hidden based on `data-dialog-open-value` provided in html.
This is strange behaviour because if i have `data-dialog-open-value="true"` and i close dialog, then go back/forward to another site and go forward/back to previous site dialog is again open.
After my changes browser remember changed `data-dialog-open-value` and when i go to previous site dialog will be closed if i closed it before.