### PR TITLE
Add aria-expanded and aria-controls to dropdown

### DIFF
--- a/.changeset/dropdown-aria-disclosure.md
+++ b/.changeset/dropdown-aria-disclosure.md
@@ -1,0 +1,11 @@
+---
+"@stimulus-components/dropdown": minor
+---
+
+Keep the `aria-expanded` attribute of the button in sync with the state of the menu.
+
+The controller accepts a new `button` target, the element that opens the menu. When it is present, `connect`, `toggle` and `hide` write `aria-expanded` on it: `true` once the menu opens, `false` once it closes, whether it is closed from the button, from an item inside the menu, or by a click outside. A screen reader could not tell whether the menu was open or closed before. The markup in the documentation also points the button at the menu with `aria-controls`, which completes the [ARIA disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).
+
+The attribute comes from the synchronous `transitioned` flag of `useTransition`, not from the classes of the menu, so it never drifts while the leave transition plays. `connect` also corrects a value that does not match the initial state of the menu.
+
+The target is optional: without it the controller writes no attribute, so existing markup is unchanged.

--- a/components/dropdown/index.html
+++ b/components/dropdown/index.html
@@ -23,7 +23,10 @@
           <div>
             <button
               type="button"
+              data-dropdown-target="button"
               data-action="dropdown#toggle click@window->dropdown#hide"
+              aria-expanded="false"
+              aria-controls="dropdown-menu"
               class="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-indigo-500"
             >
               Options
@@ -44,6 +47,7 @@
           </div>
 
           <div
+            id="dropdown-menu"
             data-dropdown-target="menu"
             class="hidden transition transform origin-top-left absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
             data-transition-enter-from="opacity-0 scale-95"

--- a/components/dropdown/spec/index.test.ts
+++ b/components/dropdown/spec/index.test.ts
@@ -28,7 +28,14 @@ beforeEach((): void => {
 
   document.body.innerHTML = `
     <div id="dropdown" data-controller="dropdown">
-      <button id="toggle" type="button" data-action="dropdown#toggle click@window->dropdown#hide">Options</button>
+      <button
+        id="toggle"
+        type="button"
+        data-dropdown-target="button"
+        data-action="dropdown#toggle click@window->dropdown#hide"
+        aria-expanded="false"
+        aria-controls="menu"
+      >Options</button>
       <div id="menu" data-dropdown-target="menu" class="hidden">
         <a id="item" href="#" data-action="dropdown#toggle">Account settings</a>
       </div>
@@ -39,6 +46,7 @@ beforeEach((): void => {
 
 const menu = (): HTMLElement => document.querySelector("#menu")
 const isOpen = (): boolean => !menu().classList.contains("hidden")
+const expanded = (): string => document.querySelector("#toggle").getAttribute("aria-expanded")
 
 describe("#toggle", () => {
   it("starts closed", (): void => {
@@ -105,5 +113,88 @@ describe("#hide", () => {
     document.querySelector<HTMLButtonElement>("#outside").click()
 
     expect(isOpen()).toBe(false)
+  })
+})
+
+describe("aria-expanded", () => {
+  it("starts collapsed", (): void => {
+    expect(expanded()).toEqual("false")
+  })
+
+  it("follows the menu when the button is clicked", (): void => {
+    const button = document.querySelector<HTMLButtonElement>("#toggle")
+
+    button.click()
+
+    expect(expanded()).toEqual("true")
+
+    // The leave animation resolves asynchronously, the attribute must not wait for it.
+    button.click()
+
+    expect(expanded()).toEqual("false")
+  })
+
+  it("collapses when an item inside the menu is clicked", (): void => {
+    document.querySelector<HTMLButtonElement>("#toggle").click()
+
+    expect(expanded()).toEqual("true")
+
+    document.querySelector<HTMLAnchorElement>("#item").click()
+
+    expect(expanded()).toEqual("false")
+  })
+
+  it("collapses on a click outside the controller element", (): void => {
+    document.querySelector<HTMLButtonElement>("#toggle").click()
+
+    expect(expanded()).toEqual("true")
+
+    document.querySelector<HTMLButtonElement>("#outside").click()
+
+    expect(expanded()).toEqual("false")
+  })
+
+  describe("with a stale attribute in the markup", () => {
+    beforeEach((): void => {
+      application.stop()
+
+      document.body.innerHTML = `
+        <div data-controller="dropdown">
+          <button id="toggle" type="button" data-dropdown-target="button" aria-expanded="true">Options</button>
+          <div id="menu" data-dropdown-target="menu" class="hidden"></div>
+        </div>
+      `
+
+      startStimulus()
+    })
+
+    it("corrects it on connect", (): void => {
+      expect(expanded()).toEqual("false")
+    })
+  })
+
+  describe("without a button target", () => {
+    beforeEach((): void => {
+      application.stop()
+
+      document.body.innerHTML = `
+        <div data-controller="dropdown">
+          <button id="toggle" type="button" data-action="dropdown#toggle click@window->dropdown#hide">Options</button>
+          <div id="menu" data-dropdown-target="menu" class="hidden"></div>
+        </div>
+        <button id="outside" type="button">Elsewhere</button>
+      `
+
+      startStimulus()
+    })
+
+    it("leaves the button alone and still opens the menu", (): void => {
+      const button = document.querySelector<HTMLButtonElement>("#toggle")
+
+      button.click()
+
+      expect(isOpen()).toBe(true)
+      expect(button.hasAttribute("aria-expanded")).toBe(false)
+    })
   })
 })

--- a/components/dropdown/src/index.ts
+++ b/components/dropdown/src/index.ts
@@ -31,9 +31,11 @@ export default class Dropdown extends Controller {
     }
   }
 
+  // `useTransition` flips `transitioned` synchronously, before the enter and leave
+  // animations resolve, so the attribute never lags behind the state of the menu.
   private syncExpanded(): void {
     if (!this.hasButtonTarget) return
 
-    this.buttonTarget.setAttribute("aria-expanded", this.transitioned.toString())
+    this.buttonTarget.setAttribute("aria-expanded", String(this.transitioned))
   }
 }

--- a/components/dropdown/src/index.ts
+++ b/components/dropdown/src/index.ts
@@ -3,25 +3,37 @@ import { useTransition } from "stimulus-use"
 
 export default class Dropdown extends Controller {
   declare readonly menuTarget: HTMLElement
+  declare readonly hasButtonTarget: boolean
+  declare readonly buttonTarget: HTMLElement
   declare toggleTransition: (event?: Event) => void
   declare leave: (event?: Event) => void
-  declare transitioned: false
+  declare transitioned: boolean
 
-  static targets = ["menu"]
+  static targets = ["menu", "button"]
 
   connect(): void {
     useTransition(this, {
       element: this.menuTarget,
     })
+
+    this.syncExpanded()
   }
 
   toggle(): void {
     this.toggleTransition()
+    this.syncExpanded()
   }
 
   hide(event: Event): void {
     if (!this.element.contains(event.target as Node) && !this.menuTarget.classList.contains("hidden")) {
       this.leave()
+      this.syncExpanded()
     }
+  }
+
+  private syncExpanded(): void {
+    if (!this.hasButtonTarget) return
+
+    this.buttonTarget.setAttribute("aria-expanded", this.transitioned.toString())
   }
 }

--- a/docs/components/content/Demo/Dropdown.vue
+++ b/docs/components/content/Demo/Dropdown.vue
@@ -4,7 +4,10 @@
       <div>
         <button
           type="button"
+          data-dropdown-target="button"
           data-action="dropdown#toggle click@window->dropdown#hide"
+          aria-expanded="false"
+          aria-controls="dropdown-menu"
           class="inline-flex justify-center items-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none"
         >
           Options
@@ -14,6 +17,7 @@
       </div>
 
       <div
+        id="dropdown-menu"
         data-dropdown-target="menu"
         class="hidden transition transform origin-top-left absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
         data-transition-enter-from="opacity-0 scale-95"

--- a/docs/content/docs/stimulus-dropdown.md
+++ b/docs/content/docs/stimulus-dropdown.md
@@ -21,9 +21,18 @@ This controller uses [stimulus-use/use-transition](https://stimulus-use.github.i
 
 ```html
 <div data-controller="dropdown" class="relative">
-  <button type="button" data-action="dropdown#toggle click@window->dropdown#hide">Options</button>
+  <button
+    type="button"
+    data-dropdown-target="button"
+    data-action="dropdown#toggle click@window->dropdown#hide"
+    aria-expanded="false"
+    aria-controls="dropdown-menu"
+  >
+    Options
+  </button>
 
   <div
+    id="dropdown-menu"
     data-dropdown-target="menu"
     class="hidden transition transform origin-top-right absolute right-0"
     data-transition-enter-from="opacity-0 scale-95"

--- a/docs/content/docs/stimulus-dropdown.md
+++ b/docs/content/docs/stimulus-dropdown.md
@@ -53,6 +53,14 @@ This controller uses [stimulus-use/use-transition](https://stimulus-use.github.i
 [TailwindCSS](https://tailwindcss.com/){target="\_blank" .underline .hover:no-underline} is used in this example, but it's up to you to style the dropdown as you want.
 ::
 
+## Accessibility
+
+The markup follows the [ARIA disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/){target="\_blank" .underline .hover:no-underline}: the button that opens the menu points to it with `aria-controls`, and tells whether it is open with `aria-expanded`.
+
+Add a `button` target to that button and the controller keeps `aria-expanded` in sync: it writes `true` when the menu opens and `false` when it closes, whether the menu is closed from the button, from an item, or by a click outside. The attribute is also corrected when the controller connects, so the initial value in your markup never drifts.
+
+The target is optional. Without it the controller touches no attribute, and markup written before this behavior existed keeps working.
+
 ## Extending Controller
 
 ::extending-controller


### PR DESCRIPTION
Follow the ARIA disclosure pattern (https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/): the toggle button now exposes aria-expanded, kept in sync by the controller on connect/toggle/hide, and references the menu via aria-controls.

The controller tracks state through a new button target and reads the synchronous transitioned flag from useTransition so aria-expanded never drifts out of sync during the close transition. Existing setups without a button target are unaffected (hasButtonTarget guard).