### PR TITLE
Add an importmap tab to the installation block

### DIFF
--- a/docs/components/content/InstallationBlock.vue
+++ b/docs/components/content/InstallationBlock.vue
@@ -31,6 +31,10 @@
         <CodeBlock :clipboard-content="selectedTab.installCommand" icon="Terminal">
           <ContentRenderer :value="selectedTab.markdownContent" />
         </CodeBlock>
+
+        <p v-if="selectedTab.note" class="text-sm text-gray-500 dark:text-gray-400 mt-3">
+          {{ selectedTab.note }}
+        </p>
       </li>
 
       <li
@@ -42,7 +46,7 @@
         </h3>
 
         <CodeBlock tab-name="app/javascript/controllers/index.js">
-          <ContentRenderer :value="importMarkdown" />
+          <ContentRenderer :value="selectedTab.importMarkdown" />
         </CodeBlock>
       </li>
     </ol>
@@ -50,6 +54,7 @@
 </template>
 
 <script setup>
+import { MapPinIcon } from "@heroicons/vue/24/solid"
 import { codeToMarkdown, toPascalCase } from "@/utils"
 import YarnIcon from "@/components/Icons/YarnIcon.vue"
 import NpmIcon from "@/components/Icons/NpmIcon.vue"
@@ -75,12 +80,32 @@ const props = defineProps({
   },
 })
 
-const getTabMarkdown = async (prefix) => {
-  const installCommand = `${prefix} ${props.packagePath} ${props.extraPackages}`
+const className = toPascalCase(props.package)
+const identifier = props.controllerName || props.package
+
+const bundlerImport = `
+import { Application } from '@hotwired/stimulus'
+import ${className} from '${props.packagePath}'
+
+const application = Application.start()
+application.register('${identifier}', ${className})
+`
+
+// In a Rails app with importmaps, the application instance already exists.
+const importmapImport = `
+import { application } from 'controllers/application'
+import ${className} from '${props.packagePath}'
+
+application.register('${identifier}', ${className})
+`
+
+const getTabMarkdown = async (prefix, importContent = bundlerImport) => {
+  const installCommand = `${prefix} ${props.packagePath} ${props.extraPackages}`.trim()
 
   return {
     installCommand,
     markdownContent: await codeToMarkdown(`$ ${installCommand}`, "bash"),
+    importMarkdown: await codeToMarkdown(importContent, "js"),
   }
 }
 
@@ -106,17 +131,13 @@ const tabs = [
     ...(await getTabMarkdown("bun add")),
     icon: BunIcon,
   },
+  {
+    filename: "importmap",
+    ...(await getTabMarkdown("bin/importmap pin", importmapImport)),
+    icon: MapPinIcon,
+    iconClass: "text-[#D30001]",
+    note: `This pins the package from a CDN into your config/importmap.rb. Importmaps don't work well with external dependencies, and not at all with CSS.`,
+  },
 ]
 const selectedTab = computed(() => tabs.find((_, index) => index === selectedIndex.value))
-
-const className = toPascalCase(props.package)
-const content = `
-import { Application } from '@hotwired/stimulus'
-import ${className} from '${props.packagePath}'
-
-const application = Application.start()
-application.register('${props.controllerName || props.package}', ${className})
-`
-
-const importMarkdown = await codeToMarkdown(content, "js")
 </script>


### PR DESCRIPTION
Closes #162.

Adds an `importmap` tab to the installation block, so people don't have to remember the `bin/importmap pin` command. Everything lives in `docs/components/content/InstallationBlock.vue`, so it applies to all 32 component doc pages at once.

### Changes

**1. New `importmap` tab** alongside yarn/npm/pnpm/bun:

```bash
$ bin/importmap pin @stimulus-components/dropdown
```

It respects `extraPackages` too — `stimulus-sortable` renders `bin/importmap pin @stimulus-components/sortable sortablejs @rails/request.js`. The icon is a Heroicons map-pin in Rails red (`@heroicons/vue` was already a docs dependency).

**2. Step 2 now follows the selected tab.** The issue also asked to document _how to import_ the component with importmaps, so `importMarkdown` moved onto each tab. The bundler tabs keep the existing `Application.start()` snippet; the importmap tab shows the Rails-idiomatic form that reuses the application instance the app already has:

```js
import { application } from 'controllers/application'
import Dropdown from '@stimulus-components/dropdown'

application.register('dropdown', Dropdown)
```

**3. A note under the install command**, rendered only for tabs that define one. It repeats the caveat already documented on `/docs/installation`: the pin comes from a CDN into `config/importmap.rb`, and importmaps don't work well with external dependencies and not at all with CSS.

Also trimmed the install command, which removes a pre-existing trailing space in the copy-to-clipboard content when `extraPackages` is empty.

### Verification

Ran the docs dev server and drove it in a real browser — clicked the importmap tab and checked the Installation section in both light and dark themes; tab, command, note, and register snippet all render correctly. Prettier passes on the file.

Two pre-existing issues are unrelated to this change (confirmed on `master` via `git stash`): `pnpm run lint` fails on `tsc` errors across `components/*` and `utils/`, and the docs pages log a Vue hydration mismatch.

Co-Authored-By: Claude Code <noreply@anthropic.com>