### PR TITLE
fix(checkbox-select-all): guard refresh against a missing checkboxAll target

### DIFF
--- a/components/checkbox-select-all/spec/index.test.ts
+++ b/components/checkbox-select-all/spec/index.test.ts
@@ -58,6 +58,37 @@ describe("#refresh", () => {
   })
 })
 
+describe("without a checkboxAll target", () => {
+  // Stimulus processes DOM mutations from a MutationObserver callback, so the
+  // target lifecycle runs a microtask after innerHTML is assigned.
+  const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+  let controller: CheckboxSelectAll
+
+  beforeEach(async (): Promise<void> => {
+    document.body.innerHTML = `
+      <form id="form" data-controller="checkbox-select-all">
+        <input id="checkbox" type="checkbox" data-checkbox-select-all-target="checkbox" />
+      </form>
+    `
+
+    await flush()
+
+    controller = application.getControllerForElementAndIdentifier(
+      document.querySelector("#form"),
+      "checkbox-select-all",
+    ) as CheckboxSelectAll
+  })
+
+  it("connects the controller", (): void => {
+    expect(controller).not.toBeNull()
+  })
+
+  it("refreshes without raising", (): void => {
+    expect((): void => controller.refresh()).not.toThrow()
+  })
+})
+
 describe("when disabled indeterminate state", () => {
   beforeEach((): void => {
     document.body.innerHTML = `

--- a/components/checkbox-select-all/src/index.ts
+++ b/components/checkbox-select-all/src/index.ts
@@ -55,6 +55,10 @@ export default class CheckboxSelectAll extends Controller {
   }
 
   refresh(): void {
+    // A checkbox target can connect or disconnect while no checkboxAll target is
+    // in the DOM, e.g. when it lives in a conditionally rendered header row.
+    if (!this.hasCheckboxAllTarget) return
+
     const checkboxesCount = this.checkboxTargets.length
     const checkboxesCheckedCount = this.checked.length
 


### PR DESCRIPTION
## Problem

`refresh()` reads `this.checkboxAllTarget` unconditionally, but it is called from both `checkboxTargetConnected` and `checkboxTargetDisconnected`. If a `checkbox` target connects or disconnects while no `checkboxAll` target is present, Stimulus raises:

```
Error: Missing target element "checkboxAll" for "checkbox-select-all" controller
  ❯ extended.refresh components/checkbox-select-all/src/index.ts:64:12
  ❯ extended.checkboxTargetConnected components/checkbox-select-all/src/index.ts:32:10
```

Real-world triggers: a select-all checkbox in a conditionally rendered header row, or a Turbo Stream that replaces part of a table so the checkboxes outlive the header.

The controller already declared `hasCheckboxAllTarget` (line 4) but never used it.

## Fix

Return early from `refresh()` when the target is absent.

## Tests

Two specs added. The regression spec calls `refresh()` directly rather than asserting on captured errors — the target-lifecycle throw escapes as an unhandled rejection and does *not* route through `application.handleError`, so an error-capturing assertion silently passes either way.

Verified the spec fails without the fix:

```
× refreshes without raising
  Tests  1 failed | 4 passed (5)
```

`pnpm run lint`, `pnpm run test`, and `pnpm -C components/checkbox-select-all run build` all pass.

No changeset — release timing is yours to decide.

Co-Authored-By: Claude Code <noreply@anthropic.com>