### PR TITLE
fix(docs): add the missing Scroll To demo

### DIFF
--- a/docs/components/content/Demo/ScrollTo.vue
+++ b/docs/components/content/Demo/ScrollTo.vue
@@ -1,0 +1,26 @@
+<template>
+  <Block title="Scroll To">
+    <a
+      id="scroll-to-demo-top"
+      href="#scroll-to-demo-bottom"
+      data-controller="scroll-to"
+      data-scroll-to-offset-value="100"
+      class="text-yellow-600"
+    >
+      Scroll down to the target &darr;
+    </a>
+
+    <!-- The controller drives window.scrollTo, so the demo needs real vertical distance to show anything. -->
+    <div class="h-96"></div>
+
+    <p id="scroll-to-demo-bottom" class="font-semibold">Here it is 🎉</p>
+
+    <a href="#scroll-to-demo-top" data-controller="scroll-to" data-scroll-to-offset-value="100" class="text-yellow-600">
+      Scroll back up &uarr;
+    </a>
+  </Block>
+</template>
+
+<script setup>
+import Block from "@/components/UI/Block.vue"
+</script>

--- a/docs/package.json
+++ b/docs/package.json
@@ -40,6 +40,7 @@
     "@stimulus-components/reveal": "workspace:*",
     "@stimulus-components/scroll-progress": "workspace:*",
     "@stimulus-components/scroll-reveal": "workspace:*",
+    "@stimulus-components/scroll-to": "workspace:*",
     "@stimulus-components/sortable": "workspace:*",
     "@stimulus-components/sound": "workspace:*",
     "@stimulus-components/speech-recognition": "workspace:*",

--- a/docs/plugins/stimulus.client.ts
+++ b/docs/plugins/stimulus.client.ts
@@ -24,6 +24,7 @@ import RemoteRails from "@stimulus-components/remote-rails/src"
 import Reveal from "@stimulus-components/reveal/src"
 import ScrollProgress from "@stimulus-components/scroll-progress/src"
 import ScrollReveal from "@stimulus-components/scroll-reveal/src"
+import ScrollTo from "@stimulus-components/scroll-to/src"
 import Sortable from "@stimulus-components/sortable/src"
 import SpeechRecognition from "@stimulus-components/speech-recognition/src"
 import Sound from "@stimulus-components/sound/src"
@@ -56,6 +57,7 @@ export default defineNuxtPlugin(() => {
   application.register("reveal", Reveal)
   application.register("scroll-progress", ScrollProgress)
   application.register("scroll-reveal", ScrollReveal)
+  application.register("scroll-to", ScrollTo)
   application.register("sortable", Sortable)
   application.register("sound", Sound)
   application.register("speech-recognition", SpeechRecognition)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       '@stimulus-components/scroll-reveal':
         specifier: workspace:*
         version: link:../components/scroll-reveal
+      '@stimulus-components/scroll-to':
+        specifier: workspace:*
+        version: link:../components/scroll-to
       '@stimulus-components/sortable':
         specifier: workspace:*
         version: link:../components/sortable


### PR DESCRIPTION
## Problem

`docs/content/docs/stimulus-scroll-to.md:14` renders `:scroll-to` under its **Example** heading, but:

- no `docs/components/content/Demo/ScrollTo.vue` existed, and
- `scroll-to` was never registered in `docs/plugins/stimulus.client.ts`

so the MDC reference resolved to nothing and the Example section rendered empty on the live site. It was the only doc page referencing a demo that doesn't exist.

## Changes

- Add `Demo/ScrollTo.vue`
- Register `scroll-to` in the Stimulus plugin
- Declare `@stimulus-components/scroll-to` as a `workspace:*` dep of the docs app

The demo includes a tall spacer div: the controller drives `window.scrollTo`, so with the anchor and its target adjacent there would be nothing to observe.

## Verification

`pnpm -C docs run build` passes, and `stimulus-scroll-to.mjs` now appears in the Nitro bundle (it was absent before, since nothing imported it). Served the build and confirmed the demo markup renders:

```
$ curl -s localhost:3199/docs/stimulus-scroll-to | grep -o ...
   2 data-scroll-to-offset-value="100"
   1 Here it is 🎉
   1 Scroll down to the target
   2 scroll-to-demo-bottom
```

`pnpm run lint` passes.

Co-Authored-By: Claude Code <noreply@anthropic.com>

## Additional evidence

Running `pnpm run -C docs generate` (what Netlify deploys) on `master` prerenders the unresolved component straight into the shipped HTML:

```html
<h2>Example</h2><ScrollTo></ScrollTo><h2 id="usage">Usage</h2>
```

So this wasn't just an empty section — a literal `<ScrollTo>` tag was being served to visitors. #204 adds `docs generate` to CI, which would catch this class of bug.
