### PR TITLE
fix(glow,textarea-autogrow): ship type declarations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Prettier: no semicolons, print width 120 (`.prettierrc`). ESLint uses flat confi
 
 Note: `pnpm run lint` and `pnpm run build:components` do not type-check identically — the root compile resolves Node's `setTimeout` (returns `NodeJS.Timeout`) while per-component declaration emit resolves the DOM one (returns `number`), so a `@ts-expect-error` that passes lint can still fail the build. **Always run the component build before assuming type changes are clean.**
 
-TypeScript is pinned to the 6.0 line: typescript-eslint does not support TS 7 yet (`@typescript-eslint/parser` caps at `<6.1.0`), so bumping TypeScript to `latest` breaks `pnpm run lint` outright. Declaration emit also needs an explicit `--rootDir` under TS 6; each component's `types` script passes `--rootDir src`, except `auto-submit` and `scroll-progress`, which import the shared `utils/` and therefore use `--rootDir ../..` and emit to `dist/types/components/<name>/src/index.d.ts`.
+TypeScript is pinned to the 6.0 line: typescript-eslint does not support TS 7 yet (`@typescript-eslint/parser` caps at `<6.1.0`), so bumping TypeScript to `latest` breaks `pnpm run lint` outright. Declaration emit also needs an explicit `--rootDir` under TS 6; each component's `types` script passes `--rootDir src`, except `auto-submit`, `scroll-progress`, and `textarea-autogrow`, which import the shared `utils/` and therefore use `--rootDir ../..` and emit to `dist/types/components/<name>/src/index.d.ts`.
 
 ## Publishing
 

--- a/components/glow/package.json
+++ b/components/glow/package.json
@@ -18,9 +18,11 @@
   "private": false,
   "main": "dist/stimulus-glow.umd.js",
   "module": "dist/stimulus-glow.mjs",
+  "types": "dist/types/index.d.ts",
   "scripts": {
+    "types": "tsc --noEmit false --declaration true --emitDeclarationOnly true --rootDir src --outDir dist/types",
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "vite build && pnpm run types",
     "version": "pnpm run build",
     "prepack": "pnpm run build"
   },

--- a/components/textarea-autogrow/package.json
+++ b/components/textarea-autogrow/package.json
@@ -9,9 +9,11 @@
   "private": false,
   "main": "dist/stimulus-textarea-autogrow.umd.js",
   "module": "dist/stimulus-textarea-autogrow.mjs",
+  "types": "dist/types/components/textarea-autogrow/src/index.d.ts",
   "scripts": {
+    "types": "tsc --noEmit false --declaration true --emitDeclarationOnly true --rootDir ../.. --outDir dist/types",
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "vite build && pnpm run types",
     "version": "pnpm run build",
     "prepack": "pnpm run build"
   },


### PR DESCRIPTION
## Problem

`glow` and `textarea-autogrow` are the only two components missing both the `types` package.json field **and** the `types` build script that the other 30 have. `dist/types/` was never emitted, so TypeScript consumers got:

```
error TS7016: Could not find a declaration file for module 'stimulus-glow'.
  '.../components/glow/dist/stimulus-glow.umd.js' implicitly has an 'any' type.
error TS7016: Could not find a declaration file for module 'stimulus-textarea-autogrow'.
  '.../components/textarea-autogrow/dist/stimulus-textarea-autogrow.umd.js' implicitly has an 'any' type.
```

This is the failure mode CLAUDE.md warns about — it fails silently until someone installs the package.

## Changes

- Add the `types` field and `types` script to both packages
- `textarea-autogrow` imports the shared `utils/`, so like `auto-submit` and `scroll-progress` it needs `--rootDir ../..`, emitting to `dist/types/components/textarea-autogrow/src/index.d.ts`
- Update the CLAUDE.md line that listed only `auto-submit` and `scroll-progress` as the `--rootDir ../..` cases
- Both `build` scripts move from `tsc --noEmit && vite build` to `vite build && pnpm run types`, matching every other component (the declaration emit type-checks the sources, so the separate `--noEmit` pass was redundant)

## Verification

Built both and confirmed the emitted paths match the declared `types` fields exactly:

```
glow               declared dist/types/index.d.ts                                        → emitted ✓
textarea-autogrow  declared dist/types/components/textarea-autogrow/src/index.d.ts       → emitted ✓
```

Then type-checked a simulated consumer (packages symlinked into a scratch `node_modules`, `strict`, `moduleResolution: bundler`). Real members resolve, and a deliberately bogus call is correctly rejected — proving the declarations load rather than silently widening to `any`:

```
index.ts(9,30): error TS2339: Property 'thisMethodDoesNotExist' does not exist on type 'default'.
```

The same consumer against the pre-fix packages produced the two TS7016 errors quoted above.

`pnpm run lint` and `pnpm run test` (35 tests) pass.

No changeset — release timing is yours.

Co-Authored-By: Claude Code <noreply@anthropic.com>
