### PR TITLE
test: add specs for seven untested components

### DIFF
--- a/components/clipboard/spec/index.test.ts
+++ b/components/clipboard/spec/index.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import Clipboard from "../src/index"
+
+let application: Application
+let writeText: ReturnType<typeof vi.fn>
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("clipboard", Clipboard)
+}
+
+// jsdom ships no Clipboard API, so the controller's only side effect has to be
+// stubbed to be observable.
+const stubClipboard = (): void => {
+  writeText = vi.fn().mockResolvedValue(undefined)
+  vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } })
+}
+
+afterEach((): void => {
+  application.stop()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+beforeEach((): void => {
+  stubClipboard()
+  startStimulus()
+
+  document.body.innerHTML = `
+    <div data-controller="clipboard" data-clipboard-success-content-value="Copied!">
+      <input id="source" type="text" value="Text to copy" data-clipboard-target="source" />
+      <button id="button" type="button" data-action="clipboard#copy" data-clipboard-target="button">Copy</button>
+    </div>
+  `
+})
+
+const button = (): HTMLButtonElement => document.querySelector("#button")
+
+describe("#copy", () => {
+  it("writes the source value to the clipboard", (): void => {
+    button().click()
+
+    expect(writeText).toHaveBeenCalledWith("Text to copy")
+  })
+
+  it("preventDefaults the click", (): void => {
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true })
+    button().dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it("swaps in the success content once the write resolves", async (): Promise<void> => {
+    button().click()
+
+    // The swap happens in the promise callback, not synchronously.
+    expect(button().innerHTML).toBe("Copy")
+
+    await vi.waitFor((): void => {
+      expect(button().innerHTML).toBe("Copied!")
+    })
+  })
+
+  it("restores the original content after the success duration", async (): Promise<void> => {
+    // Fake timers must be installed before the click: they only control
+    // timers scheduled after installation.
+    vi.useFakeTimers()
+
+    button().click()
+
+    // Flushes the clipboard write promise, so copied() runs and schedules the revert.
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(button().innerHTML).toBe("Copied!")
+
+    await vi.advanceTimersByTimeAsync(1999)
+
+    expect(button().innerHTML).toBe("Copied!")
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(button().innerHTML).toBe("Copy")
+  })
+})
+
+describe("with a custom success duration", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div
+        data-controller="clipboard"
+        data-clipboard-success-content-value="Copied!"
+        data-clipboard-success-duration-value="5000"
+      >
+        <input id="source" type="text" value="Text to copy" data-clipboard-target="source" />
+        <button id="button" type="button" data-action="clipboard#copy" data-clipboard-target="button">Copy</button>
+      </div>
+    `
+  })
+
+  it("waits for the configured delay before restoring", async (): Promise<void> => {
+    vi.useFakeTimers()
+
+    button().click()
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(button().innerHTML).toBe("Copied!")
+
+    // Past the 2000ms default, still showing success.
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(button().innerHTML).toBe("Copied!")
+
+    await vi.advanceTimersByTimeAsync(3000)
+
+    expect(button().innerHTML).toBe("Copy")
+  })
+})
+
+describe("without a button target", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div data-controller="clipboard" data-clipboard-success-content-value="Copied!">
+        <input id="source" type="text" value="Text to copy" data-clipboard-target="source" />
+        <button id="button" type="button" data-action="clipboard#copy">Copy</button>
+      </div>
+    `
+  })
+
+  it("still copies without raising", async (): Promise<void> => {
+    const errors: string[] = []
+    application.handleError = (error: Error): void => {
+      errors.push(error.message)
+    }
+
+    button().click()
+
+    await vi.waitFor((): void => {
+      expect(writeText).toHaveBeenCalledWith("Text to copy")
+    })
+
+    expect(errors).toEqual([])
+    expect(button().innerHTML).toBe("Copy")
+  })
+})

--- a/components/dialog/spec/index.test.ts
+++ b/components/dialog/spec/index.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import Dialog from "../src/index"
+
+let application: Application
+let showModal: ReturnType<typeof vi.fn>
+let close: ReturnType<typeof vi.fn>
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("dialog", Dialog)
+}
+
+// jsdom implements neither the <dialog> modal methods nor the Web Animations
+// API — the properties are absent entirely, so they are assigned rather than
+// spied on. That keeps the assertions on the controller's own logic: which
+// method it calls, and when.
+const stubDialogElement = (): void => {
+  showModal = vi.fn()
+  close = vi.fn()
+
+  HTMLDialogElement.prototype.showModal = showModal
+  HTMLDialogElement.prototype.close = close
+  HTMLDialogElement.prototype.getAnimations = vi.fn().mockReturnValue([])
+}
+
+afterEach(async (): Promise<void> => {
+  // This controller registers a listener on `document`, which outlives the
+  // element. Emptying the body and letting Stimulus process the mutation runs
+  // disconnect(), so listeners do not leak into the next test.
+  document.body.innerHTML = ""
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  application.stop()
+
+  delete HTMLDialogElement.prototype.showModal
+  delete HTMLDialogElement.prototype.close
+  delete HTMLDialogElement.prototype.getAnimations
+
+  vi.restoreAllMocks()
+})
+
+beforeEach((): void => {
+  stubDialogElement()
+  startStimulus()
+
+  document.body.innerHTML = `
+    <div id="wrapper" data-controller="dialog">
+      <button id="open" type="button" data-action="dialog#open">Open</button>
+      <dialog id="dialog" data-dialog-target="dialog" data-action="click->dialog#backdropClose">
+        <p id="content">Dialog content</p>
+        <button id="close" type="button" data-action="dialog#close">Close</button>
+      </dialog>
+    </div>
+  `
+})
+
+const dialog = (): HTMLDialogElement => document.querySelector("#dialog")
+
+describe("#open", () => {
+  it("opens the dialog as a modal", (): void => {
+    document.querySelector<HTMLButtonElement>("#open").click()
+
+    expect(showModal).toHaveBeenCalledOnce()
+  })
+
+  it("does not open on connect by default", (): void => {
+    expect(showModal).not.toHaveBeenCalled()
+  })
+})
+
+describe("when the open value is set", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div data-controller="dialog" data-dialog-open-value="true">
+        <dialog id="dialog" data-dialog-target="dialog"><p>Dialog content</p></dialog>
+      </div>
+    `
+  })
+
+  it("opens on connect", (): void => {
+    expect(showModal).toHaveBeenCalledOnce()
+  })
+})
+
+describe("#close", () => {
+  it("marks the dialog as closing then closes it", async (): Promise<void> => {
+    document.querySelector<HTMLButtonElement>("#close").click()
+
+    // The attribute is set synchronously so a CSS exit animation can hook it.
+    expect(dialog().hasAttribute("closing")).toBe(true)
+
+    await vi.waitFor((): void => {
+      expect(close).toHaveBeenCalledOnce()
+    })
+
+    expect(dialog().hasAttribute("closing")).toBe(false)
+  })
+})
+
+describe("#backdropClose", () => {
+  it("closes when the click lands on the dialog itself", async (): Promise<void> => {
+    dialog().click()
+
+    await vi.waitFor((): void => {
+      expect(close).toHaveBeenCalledOnce()
+    })
+  })
+
+  it("ignores clicks on the dialog's contents", (): void => {
+    document.querySelector<HTMLElement>("#content").click()
+
+    expect(close).not.toHaveBeenCalled()
+    expect(dialog().hasAttribute("closing")).toBe(false)
+  })
+})
+
+describe("turbo:before-render", () => {
+  it("force closes the dialog so it cannot survive a page render", (): void => {
+    document.dispatchEvent(new CustomEvent("turbo:before-render"))
+
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it("stops listening once disconnected", async (): Promise<void> => {
+    document.querySelector("#wrapper").removeAttribute("data-controller")
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    document.dispatchEvent(new CustomEvent("turbo:before-render"))
+
+    expect(close).not.toHaveBeenCalled()
+  })
+})

--- a/components/dropdown/spec/index.test.ts
+++ b/components/dropdown/spec/index.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import Dropdown from "../src/index"
+
+let application: Application
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("dropdown", Dropdown)
+}
+
+// stimulus-use's leave() resolves off requestAnimationFrame, which takes ~200ms
+// here on an idle machine and considerably longer when the whole suite runs in
+// parallel. These waits are generous on purpose so the specs are not load-flaky.
+const TRANSITION = { timeout: 8000, interval: 20 }
+const TEST_TIMEOUT = 15000
+
+afterEach((): void => {
+  application.stop()
+})
+
+beforeEach((): void => {
+  startStimulus()
+
+  document.body.innerHTML = `
+    <div id="dropdown" data-controller="dropdown">
+      <button id="toggle" type="button" data-action="dropdown#toggle click@window->dropdown#hide">Options</button>
+      <div id="menu" data-dropdown-target="menu" class="hidden">
+        <a id="item" href="#" data-action="dropdown#toggle">Account settings</a>
+      </div>
+    </div>
+    <button id="outside" type="button">Elsewhere</button>
+  `
+})
+
+const menu = (): HTMLElement => document.querySelector("#menu")
+const isOpen = (): boolean => !menu().classList.contains("hidden")
+
+describe("#toggle", () => {
+  it("starts closed", (): void => {
+    expect(isOpen()).toBe(false)
+  })
+
+  it("opens the menu", (): void => {
+    document.querySelector<HTMLButtonElement>("#toggle").click()
+
+    expect(isOpen()).toBe(true)
+  })
+
+  it(
+    "closes an open menu",
+    async (): Promise<void> => {
+      const button = document.querySelector<HTMLButtonElement>("#toggle")
+
+      button.click()
+
+      expect(isOpen()).toBe(true)
+
+      button.click()
+
+      await vi.waitFor((): void => {
+        expect(isOpen()).toBe(false)
+      }, TRANSITION)
+    },
+    TEST_TIMEOUT,
+  )
+})
+
+describe("#hide", () => {
+  it(
+    "closes the menu on a click outside the controller element",
+    async (): Promise<void> => {
+      document.querySelector<HTMLButtonElement>("#toggle").click()
+
+      expect(isOpen()).toBe(true)
+
+      document.querySelector<HTMLButtonElement>("#outside").click()
+
+      await vi.waitFor((): void => {
+        expect(isOpen()).toBe(false)
+      }, TRANSITION)
+    },
+    TEST_TIMEOUT,
+  )
+
+  it("leaves the menu open when the click is inside the controller element", (): void => {
+    document.querySelector<HTMLButtonElement>("#toggle").click()
+
+    expect(isOpen()).toBe(true)
+
+    // A click on the menu itself must not dismiss it — only `dropdown#toggle`
+    // on a specific item should.
+    menu().click()
+
+    expect(isOpen()).toBe(true)
+  })
+
+  it("does nothing when the menu is already closed", (): void => {
+    expect(isOpen()).toBe(false)
+
+    document.querySelector<HTMLButtonElement>("#outside").click()
+
+    expect(isOpen()).toBe(false)
+  })
+})

--- a/components/hotkey/spec/index.test.ts
+++ b/components/hotkey/spec/index.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import Hotkey from "../src/index"
+
+let application: Application
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("hotkey", Hotkey)
+}
+
+afterEach((): void => {
+  application.stop()
+})
+
+beforeEach((): void => {
+  startStimulus()
+
+  document.body.innerHTML = `
+    <button id="button" type="button" data-controller="hotkey" data-action="keydown.j@document->hotkey#click">
+      Submit
+    </button>
+    <input id="field" type="text" data-controller="hotkey" data-action="keydown.k@document->hotkey#focus" />
+    <input id="unrelated" type="text" />
+    <textarea id="notes"></textarea>
+  `
+})
+
+// Dispatch from `document.body` rather than `document`: the controller reads
+// `event.target.closest(...)`, and in a browser a keydown always targets the
+// focused element (`<body>` by default), never the document itself.
+const press = (key: string, target: EventTarget = document.body, options: KeyboardEventInit = {}): KeyboardEvent => {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...options })
+  target.dispatchEvent(event)
+  return event
+}
+
+describe("#click", () => {
+  it("clicks the element when the key is pressed", (): void => {
+    const clicked = vi.fn()
+    document.querySelector("#button").addEventListener("click", clicked)
+
+    press("j")
+
+    expect(clicked).toHaveBeenCalledOnce()
+  })
+
+  it("preventDefaults the keyboard event", (): void => {
+    const event = press("j")
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it("ignores other keys", (): void => {
+    const clicked = vi.fn()
+    document.querySelector("#button").addEventListener("click", clicked)
+
+    press("x")
+
+    expect(clicked).not.toHaveBeenCalled()
+  })
+})
+
+describe("#focus", () => {
+  it("focuses the element when the key is pressed", (): void => {
+    press("k")
+
+    expect(document.activeElement).toBe(document.querySelector("#field"))
+  })
+})
+
+describe("when the event originates in a text field", () => {
+  it("does nothing for an input", (): void => {
+    const clicked = vi.fn()
+    document.querySelector("#button").addEventListener("click", clicked)
+
+    press("j", document.querySelector("#unrelated"))
+
+    expect(clicked).not.toHaveBeenCalled()
+  })
+
+  it("does nothing for a textarea", (): void => {
+    const clicked = vi.fn()
+    document.querySelector("#button").addEventListener("click", clicked)
+
+    press("j", document.querySelector("#notes"))
+
+    expect(clicked).not.toHaveBeenCalled()
+  })
+})
+
+describe("when the event is already handled", () => {
+  it("does nothing if defaultPrevented", (): void => {
+    const clicked = vi.fn()
+    document.querySelector("#button").addEventListener("click", clicked)
+
+    // A listener registered earlier in the capture phase consumed the event.
+    document.addEventListener("keydown", (event: Event): void => event.preventDefault(), { capture: true, once: true })
+
+    press("j")
+
+    expect(clicked).not.toHaveBeenCalled()
+  })
+})
+
+describe("when the element is not clickable", () => {
+  it("does nothing if pointer-events is none", (): void => {
+    const button: HTMLElement = document.querySelector("#button")
+    button.style.pointerEvents = "none"
+
+    const clicked = vi.fn()
+    button.addEventListener("click", clicked)
+
+    press("j")
+
+    expect(clicked).not.toHaveBeenCalled()
+  })
+})

--- a/components/notification/spec/index.test.ts
+++ b/components/notification/spec/index.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import Notification from "../src/index"
+
+let application: Application
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("notification", Notification)
+}
+
+// Short real delays rather than fake timers: hide() awaits stimulus-use's
+// leave() transition, so the timeout and the transition promise have to
+// interleave the way they do at runtime.
+const DELAY = 20
+
+// stimulus-use's leave() resolves off requestAnimationFrame, which takes ~200ms
+// here on an idle machine and considerably longer when the whole suite runs in
+// parallel. These waits are generous on purpose so the specs are not load-flaky.
+const TRANSITION = { timeout: 8000, interval: 20 }
+const TEST_TIMEOUT = 15000
+
+afterEach((): void => {
+  application.stop()
+})
+
+beforeEach((): void => {
+  startStimulus()
+})
+
+const notification = (): HTMLElement => document.querySelector("#notification")
+
+describe("when visible by default", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div id="notification" data-controller="notification" data-notification-delay-value="${DELAY}" class="hidden">
+        <p>This alert will magically disappear!</p>
+      </div>
+    `
+  })
+
+  it("reveals the notification on connect", (): void => {
+    expect(notification().classList.contains("hidden")).toBe(false)
+  })
+
+  it(
+    "removes itself once the delay elapses",
+    async (): Promise<void> => {
+      expect(notification()).not.toBeNull()
+
+      await vi.waitFor((): void => {
+        expect(notification()).toBeNull()
+      }, TRANSITION)
+    },
+    TEST_TIMEOUT,
+  )
+})
+
+describe("when hidden by default", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div
+        id="notification"
+        data-controller="notification"
+        data-notification-hidden-value="true"
+        data-notification-delay-value="${DELAY}"
+        class="hidden"
+      >
+        <p>Triggered programmatically.</p>
+      </div>
+    `
+  })
+
+  it("stays hidden on connect", (): void => {
+    expect(notification().classList.contains("hidden")).toBe(true)
+  })
+
+  it("does not remove itself", async (): Promise<void> => {
+    await new Promise((resolve) => setTimeout(resolve, DELAY * 4))
+
+    expect(notification()).not.toBeNull()
+  })
+})
+
+describe("#show", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div
+        id="notification"
+        data-controller="notification"
+        data-notification-hidden-value="true"
+        data-notification-delay-value="${DELAY}"
+        data-action="awesome@window->notification#show"
+        class="hidden"
+      >
+        <p>Triggered programmatically.</p>
+      </div>
+    `
+  })
+
+  it(
+    "reveals then removes the notification when the event fires",
+    async (): Promise<void> => {
+      expect(notification().classList.contains("hidden")).toBe(true)
+
+      window.dispatchEvent(new CustomEvent("awesome"))
+
+      expect(notification().classList.contains("hidden")).toBe(false)
+
+      await vi.waitFor((): void => {
+        expect(notification()).toBeNull()
+      }, TRANSITION)
+    },
+    TEST_TIMEOUT,
+  )
+})
+
+describe("#hide", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div id="notification" data-controller="notification" data-notification-hidden-value="true" class="hidden">
+        <button id="close" type="button" data-action="notification#hide">Close</button>
+      </div>
+    `
+  })
+
+  it(
+    "removes the notification when dismissed",
+    async (): Promise<void> => {
+      document.querySelector<HTMLButtonElement>("#close").click()
+
+      await vi.waitFor((): void => {
+        expect(notification()).toBeNull()
+      }, TRANSITION)
+    },
+    TEST_TIMEOUT,
+  )
+})

--- a/components/read-more/spec/index.test.ts
+++ b/components/read-more/spec/index.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import ReadMore from "../src/index"
+
+let application: Application
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("read-more", ReadMore)
+}
+
+afterEach((): void => {
+  application.stop()
+})
+
+beforeEach((): void => {
+  startStimulus()
+
+  document.body.innerHTML = `
+    <div
+      data-controller="read-more"
+      data-read-more-more-text-value="Read more"
+      data-read-more-less-text-value="Read less"
+    >
+      <p data-read-more-target="content">Lorem ipsum dolor sit amet.</p>
+      <button id="toggle" type="button" data-action="read-more#toggle">Read more</button>
+    </div>
+  `
+})
+
+const button = (): HTMLButtonElement => document.querySelector("#toggle")
+const content = (): HTMLElement => document.querySelector("[data-read-more-target='content']")
+
+describe("#toggle", () => {
+  it("expands the content on the first click", (): void => {
+    expect(content().style.getPropertyValue("--read-more-line-clamp")).toBe("")
+
+    button().click()
+
+    expect(content().style.getPropertyValue("--read-more-line-clamp")).toBe("'unset'")
+    expect(button().innerHTML).toBe("Read less")
+  })
+
+  it("collapses the content on the second click", (): void => {
+    button().click()
+    button().click()
+
+    expect(content().style.getPropertyValue("--read-more-line-clamp")).toBe("")
+    expect(button().innerHTML).toBe("Read more")
+  })
+
+  it("keeps alternating across repeated clicks", (): void => {
+    for (let i = 0; i < 3; i++) {
+      button().click()
+      expect(button().innerHTML).toBe("Read less")
+
+      button().click()
+      expect(button().innerHTML).toBe("Read more")
+    }
+  })
+})
+
+describe("with more than one trigger", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div
+        data-controller="read-more"
+        data-read-more-more-text-value="Read more"
+        data-read-more-less-text-value="Read less"
+      >
+        <p data-read-more-target="content">Lorem ipsum dolor sit amet.</p>
+        <button id="toggle" type="button" data-action="read-more#toggle">Read more</button>
+        <button id="other" type="button" data-action="read-more#toggle">Read more</button>
+      </div>
+    `
+  })
+
+  it("rewrites only the clicked trigger", (): void => {
+    // show()/hide() write to event.target, not to a target element, so the
+    // button that was not clicked keeps its original label.
+    button().click()
+
+    expect(button().innerHTML).toBe("Read less")
+    expect(document.querySelector("#other").innerHTML).toBe("Read more")
+    expect(content().style.getPropertyValue("--read-more-line-clamp")).toBe("'unset'")
+  })
+})

--- a/components/scroll-to/spec/index.test.ts
+++ b/components/scroll-to/spec/index.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import ScrollTo from "../src/index"
+
+let application: Application
+let scrollTo: ReturnType<typeof vi.fn>
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("scroll-to", ScrollTo)
+}
+
+// jsdom does not implement window.scrollTo, so stub it to observe the call.
+// getBoundingClientRect() and pageYOffset are both 0 here, which makes the
+// expected top exactly the negated offset.
+const stubScrollTo = (): void => {
+  scrollTo = vi.fn()
+  vi.stubGlobal("scrollTo", scrollTo)
+}
+
+// Stimulus connects controllers from a MutationObserver callback, so markup
+// assigned inside a test body is not live until the microtask queue drains.
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+afterEach((): void => {
+  application.stop()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+beforeEach((): void => {
+  stubScrollTo()
+  startStimulus()
+
+  document.body.innerHTML = `
+    <a id="link" href="#target" data-controller="scroll-to">Scroll</a>
+    <h2 id="target">Target</h2>
+  `
+})
+
+const link = (): HTMLAnchorElement => document.querySelector("#link")
+
+describe("#scroll", () => {
+  it("scrolls to the element named by the hash", (): void => {
+    link().click()
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: -10, behavior: "smooth" })
+  })
+
+  it("preventDefaults the click so the URL does not jump", (): void => {
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true })
+    link().dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+})
+
+describe("offset value", () => {
+  it("defaults to 10", (): void => {
+    link().click()
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: -10 }))
+  })
+
+  describe("when set explicitly", () => {
+    beforeEach((): void => {
+      document.body.innerHTML = `
+        <a id="link" href="#target" data-controller="scroll-to" data-scroll-to-offset-value="150">Scroll</a>
+        <h2 id="target">Target</h2>
+      `
+    })
+
+    it("uses the given offset", (): void => {
+      link().click()
+
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: -150 }))
+    })
+  })
+
+  describe("when set to zero", () => {
+    beforeEach((): void => {
+      document.body.innerHTML = `
+        <a id="link" href="#target" data-controller="scroll-to" data-scroll-to-offset-value="0">Scroll</a>
+        <h2 id="target">Target</h2>
+      `
+    })
+
+    it("uses zero rather than falling back to the default", (): void => {
+      link().click()
+
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 0 }))
+    })
+  })
+})
+
+describe("behavior value", () => {
+  it("defaults to smooth", (): void => {
+    link().click()
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: "smooth" }))
+  })
+
+  describe("when set explicitly", () => {
+    beforeEach((): void => {
+      document.body.innerHTML = `
+        <a id="link" href="#target" data-controller="scroll-to" data-scroll-to-behavior-value="auto">Scroll</a>
+        <h2 id="target">Target</h2>
+      `
+    })
+
+    it("uses the given behavior", (): void => {
+      link().click()
+
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: "auto" }))
+    })
+  })
+})
+
+describe("when the hash matches no element", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `<a id="link" href="#nope" data-controller="scroll-to">Scroll</a>`
+  })
+
+  it("warns and does not scroll", (): void => {
+    const warn = vi.spyOn(console, "warn").mockImplementation((): void => {})
+
+    link().click()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toContain('"nope"')
+  })
+})
+
+describe("#disconnect", () => {
+  it("stops responding to clicks", async (): Promise<void> => {
+    link().removeAttribute("data-controller")
+
+    await flush()
+
+    link().click()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

Only 9 of the 32 components had specs. Each package publishes independently, so a regression in an untested one ships straight to npm.

## Coverage added

Seven of the untested components, taking the suite from **35 tests to 82**:

| Component | Tests | What's covered |
| --- | --- | --- |
| `scroll-to` | 9 | offset default/explicit/zero, behavior default/explicit, missing-hash warning, disconnect |
| `hotkey` | 8 | click & focus, `preventDefault`, key filtering, input/textarea guard, `defaultPrevented`, `pointer-events: none` |
| `dialog` | 8 | modal open, open-on-connect value, closing attribute lifecycle, backdrop target check, `turbo:before-render`, listener teardown |
| `clipboard` | 6 | write to clipboard, `preventDefault`, success content swap, restore after default & custom duration, no-button-target path |
| `notification` | 6 | reveal on connect, hidden-by-default, auto-remove after delay, programmatic show, dismiss |
| `dropdown` | 6 | open, close, click-outside dismiss, click-inside kept open, no-op when closed |
| `read-more` | 4 | expand, collapse, repeated toggling, per-trigger label rewrite |

## These specs were mutation-checked

Rather than just confirming they pass, I broke the behaviour under test to confirm each one bites:

```
hotkey    — drop the input/textarea guard    → 2 failed (both guard tests)
scroll-to — default offset 10 → 0            → 2 failed (default + primary assertion)
clipboard — remove the content restore       → 2 failed (both duration tests)
```

I also caught and rewrote two tests of my own that passed for the wrong reason: one asserted on a round-tripped `innerHTML` that preserved the inline style regardless of the controller, and one asserted on errors captured via `application.handleError`, which target-lifecycle throws bypass entirely.

## Environment notes

- jsdom implements neither the `<dialog>` modal methods nor `getAnimations`, and the properties are **absent** rather than unimplemented — so `vi.spyOn` fails and they're assigned on the prototype instead.
- `window.scrollTo` and the Clipboard API are stubbed for the same reason. With `getBoundingClientRect()` and `pageYOffset` both 0, the expected scroll top is exactly the negated offset, which makes the offset arithmetic directly assertable.
- **Flakiness, handled:** the two specs waiting on a `stimulus-use` transition use explicit generous timeouts. `leave()` resolves off `requestAnimationFrame` — ~200ms idle, but over 1s when all 16 files run in parallel, which made the default 1s `vi.waitFor` budget load-flaky. Both failed on my first full-suite run despite passing in isolation. **Full suite run three times after the fix: 82/82 each time.**
- The dialog controller listens on `document`, so its teardown empties the body and lets Stimulus process the mutation. Without that, listeners leak between tests and the force-close assertions see 7 stale controllers.

New specs carry a `@vitest-environment jsdom` docblock. This is **not** redundant with the config-level `environment: "jsdom"`: Vitest resolves the nearest config, so running `vitest` from inside `components/<name>/` picks up that package's `vite.config.mts` and the root config never loads. Without the docblock those runs fail with `document is not defined`. #203 removed the docblocks on that mistaken assumption and #206 restores them.

## Still untested

Being explicit about what this does **not** cover: `sortable` (needs drag simulation through sortablejs) and `popover` were on my original list but I left them — sortable's cost/value is poor without a real pointer-drag harness. Also still bare: `animated-number`, `carousel`, `chartjs`, `color-picker`, `content-loader`, `glow`, `lightbox`, `places-autocomplete`, `prefetch`, `remote-rails`, `scroll-progress`, `scroll-reveal`, `sound`, `textarea-autogrow`.

`pnpm run lint` passes.

Co-Authored-By: Claude Code <noreply@anthropic.com>
