### PR TITLE
fix(content-loader): disconnect the lazy-loading IntersectionObserver

### DIFF
--- a/components/content-loader/spec/index.test.ts
+++ b/components/content-loader/spec/index.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import ContentLoader from "../src/index"
+
+let application: Application
+let fetchMock: ReturnType<typeof vi.fn>
+
+// Every observer this spec creates, so teardown can be asserted on.
+type Record = { observed: number; disconnected: boolean }
+let records: Record[]
+let callbacks: IntersectionObserverCallback[]
+
+// jsdom implements no IntersectionObserver, so a recording fake stands in. It
+// also hands back the callback, which is the only way to simulate the element
+// scrolling into view.
+const stubIntersectionObserver = (): void => {
+  records = []
+  callbacks = []
+
+  class FakeIntersectionObserver {
+    record: Record
+
+    constructor(callback: IntersectionObserverCallback) {
+      this.record = { observed: 0, disconnected: false }
+      records.push(this.record)
+      callbacks.push(callback)
+    }
+
+    observe(): void {
+      this.record.observed++
+    }
+
+    unobserve(): void {}
+
+    disconnect(): void {
+      this.record.disconnected = true
+    }
+
+    takeRecords(): [] {
+      return []
+    }
+  }
+
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
+}
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("content-loader", ContentLoader)
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+const intersect = (target: Element): void => {
+  callbacks[0]([{ isIntersecting: true, target } as IntersectionObserverEntry], {} as IntersectionObserver)
+}
+
+afterEach((): void => {
+  // Empty the body before the next Application.start(), otherwise it connects
+  // to the previous test's leftover markup and fetches again.
+  document.body.innerHTML = ""
+
+  application.stop()
+  vi.unstubAllGlobals()
+})
+
+beforeEach((): void => {
+  stubIntersectionObserver()
+  fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async (): Promise<string> => "<p>loaded</p>" })
+  vi.stubGlobal("fetch", fetchMock)
+
+  startStimulus()
+})
+
+const element = (): HTMLElement => document.querySelector("#el")
+
+describe("eager loading", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `<div id="el" data-controller="content-loader" data-content-loader-url-value="/x"></div>`
+  })
+
+  it("fetches immediately without observing", (): void => {
+    expect(fetchMock).toHaveBeenCalledWith("/x")
+    expect(records.length).toBe(0)
+  })
+})
+
+describe("lazy loading", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div
+        id="el"
+        data-controller="content-loader"
+        data-content-loader-url-value="/x"
+        data-content-loader-lazy-loading-value="true"
+      ></div>
+    `
+  })
+
+  it("observes instead of fetching straight away", (): void => {
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(records.length).toBe(1)
+    expect(records[0].observed).toBe(1)
+  })
+
+  it("fetches once the element intersects", async (): Promise<void> => {
+    intersect(element())
+
+    await flush()
+
+    expect(fetchMock).toHaveBeenCalledWith("/x")
+    expect(element().innerHTML.trim()).toBe("<p>loaded</p>")
+  })
+
+  it("stops observing after it has loaded", (): void => {
+    intersect(element())
+
+    expect(records[0].disconnected).toBe(true)
+  })
+
+  it("disconnects the observer when the controller disconnects", async (): Promise<void> => {
+    expect(records[0].disconnected).toBe(false)
+
+    // A Turbo navigation removes the element before it ever scrolled into view.
+    document.body.innerHTML = ""
+    await flush()
+
+    expect(records[0].disconnected).toBe(true)
+  })
+
+  it("does not accumulate observers across reconnects", async (): Promise<void> => {
+    const markup = document.body.innerHTML
+
+    // Turbo replaces the page and later restores it from cache.
+    document.body.innerHTML = ""
+    await flush()
+
+    document.body.innerHTML = markup
+    await flush()
+
+    expect(records.length).toBe(2)
+
+    // Only the live one is still observing; the first no longer holds the
+    // detached element or the dead controller.
+    expect(records[0].disconnected).toBe(true)
+    expect(records[1].disconnected).toBe(false)
+  })
+})
+
+describe("refresh interval", () => {
+  beforeEach((): void => {
+    vi.useFakeTimers()
+
+    document.body.innerHTML = `
+      <div
+        id="el"
+        data-controller="content-loader"
+        data-content-loader-url-value="/x"
+        data-content-loader-refresh-interval-value="1000"
+      ></div>
+    `
+  })
+
+  afterEach((): void => {
+    vi.useRealTimers()
+  })
+
+  it("refetches on the interval", async (): Promise<void> => {
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("stops refetching once disconnected", async (): Promise<void> => {
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    document.body.innerHTML = ""
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("without a url value", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `<div id="el" data-controller="content-loader"></div>`
+  })
+
+  it("logs an error and does nothing", (): void => {
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(records.length).toBe(0)
+  })
+})

--- a/components/content-loader/src/index.ts
+++ b/components/content-loader/src/index.ts
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class ContentLoader extends Controller<HTMLElement> {
   declare refreshTimer: ReturnType<typeof setInterval>
+  declare observer?: IntersectionObserver
   declare readonly hasUrlValue: boolean
   declare readonly hasLazyLoadingValue: boolean
   declare readonly hasRefreshIntervalValue: boolean
@@ -38,6 +39,7 @@ export default class ContentLoader extends Controller<HTMLElement> {
 
   disconnect(): void {
     this.stopRefreshing()
+    this.stopObserving()
   }
 
   load(): void {
@@ -54,20 +56,17 @@ export default class ContentLoader extends Controller<HTMLElement> {
       rootMargin: this.lazyLoadingRootMarginValue,
     }
 
-    const observer = new IntersectionObserver(
-      (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
-        entries.forEach((entry: IntersectionObserverEntry) => {
-          if (entry.isIntersecting) {
-            this.load()
+    this.observer = new IntersectionObserver((entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry: IntersectionObserverEntry) => {
+        if (entry.isIntersecting) {
+          this.load()
 
-            observer.unobserve(entry.target)
-          }
-        })
-      },
-      options,
-    )
+          this.stopObserving()
+        }
+      })
+    }, options)
 
-    observer.observe(this.element)
+    this.observer.observe(this.element)
   }
 
   fetch(): void {
@@ -103,6 +102,11 @@ export default class ContentLoader extends Controller<HTMLElement> {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer)
     }
+  }
+
+  stopObserving(): void {
+    this.observer?.disconnect()
+    this.observer = undefined
   }
 
   loadScripts(): void {


### PR DESCRIPTION
## Problem

`lazyLoad()` held its `IntersectionObserver` in a local variable and only ever called `unobserve` on intersection. `disconnect()` handled only the refresh timer, so the observer survived the controller — still holding a reference to the element and to the controller closure.

If the element was removed **before it ever scrolled into view** (a Turbo navigation past an offscreen loader), that observer outlived its controller. When it later fired, it would:

```
fetches:           0 -> 1                        fetch for a controller that is gone
intervalsCreated:  1      intervalsCleared: 0    an interval disconnect() already ran and can never clear
element.innerHTML: "<p>loaded</p>"               written into a detached node
```

With `lazy-loading` **and** `refresh-interval` set together, that leaves a polling loop hitting the server for the rest of the page session — and it compounds with every Turbo visit, since each one can strand another observer.

## Fix

The observer now lives on the controller and is torn down through a `stopObserving()` that mirrors the existing `stopRefreshing()`, called from both `disconnect()` and the intersection handler:

```ts
disconnect(): void {
  this.stopRefreshing()
  this.stopObserving()
}

stopObserving(): void {
  this.observer?.disconnect()
  this.observer = undefined
}
```

The handler now uses `this.observer` and `disconnect()` rather than the callback's second argument and `unobserve(entry.target)` — since the observer only ever watches one element, disconnecting it is equivalent and keeps a single teardown path.

## Tests

This component had no spec; it now has 9, covering eager vs lazy loading, the refresh interval, teardown, and Turbo-style reconnect. jsdom implements no `IntersectionObserver`, so a recording fake stands in and hands back the callback.

Verified by mutation — removing `stopObserving()` from `disconnect()` fails exactly the two teardown tests and nothing else:

```
× disconnects the observer when the controller disconnects
× does not accumulate observers across reconnects
  Tests  2 failed | 7 passed (9)
```

I dropped one test I'd first written, which fired the observer callback manually after disconnect: a browser never invokes a disconnected observer's callback, so calling it directly asserts a guarantee no fix can provide. The reconnect test covers the real scenario instead.

## Verification

- `pnpm run lint` — pass
- `pnpm run test` — 17 files, 93 tests, pass
- `pnpm -C components/content-loader run build` — exit 0

No changeset, per your call on release timing.

Co-Authored-By: Claude Code <noreply@anthropic.com>