### PR TITLE
fix(docs): correct five stale package names in Extending Controller examples

### DIFF
--- a/docs/content/docs/stimulus-auto-submit.md
+++ b/docs/content/docs/stimulus-auto-submit.md
@@ -45,7 +45,7 @@ packagePath: "@stimulus-components/auto-submit"
 ::code-block{tabName="app/javascript/controllers/auto_submit_controller.js"}
 
 ```js
-import AutoSubmit from "stimulus-auto-submit"
+import AutoSubmit from "@stimulus-components/auto-submit"
 
 export default class extends AutoSubmit {
   static values = {

--- a/docs/content/docs/stimulus-remote-rails.md
+++ b/docs/content/docs/stimulus-remote-rails.md
@@ -86,7 +86,7 @@ You can use it with all [remote elements available in Rails UJS](https://guides.
 ::code-block{tabName="app/javascript/controllers/remote_rails_controller.js"}
 
 ```js
-import Remote from "stimulus-remote-rails"
+import Remote from "@stimulus-components/remote-rails"
 
 export default class extends Remote {
   connect() {

--- a/docs/content/docs/stimulus-scroll-to.md
+++ b/docs/content/docs/stimulus-scroll-to.md
@@ -57,7 +57,7 @@ With options:
 ::code-block{tabName="app/javascript/controllers/scroll_to_controller.js"}
 
 ```js
-import ScrollTo from "stimulus-scroll-to"
+import ScrollTo from "@stimulus-components/scroll-to"
 
 export default class extends ScrollTo {
   connect() {

--- a/docs/content/docs/stimulus-sound.md
+++ b/docs/content/docs/stimulus-sound.md
@@ -38,7 +38,7 @@ packagePath: "@stimulus-components/sound"
 ::code-block{tabName="app/javascript/controllers/sound_controller.js"}
 
 ```js
-import Sound from "stimulus-sound"
+import Sound from "@stimulus-components/sound"
 
 export default class extends Sound {
   connect() {

--- a/docs/content/docs/stimulus-timeago.md
+++ b/docs/content/docs/stimulus-timeago.md
@@ -82,7 +82,7 @@ And use it in your html:
 ::code-block{tabName="app/javascript/controllers/timeago_controller.js"}
 
 ```js
-import Timeago from "stimulus-timeago"
+import Timeago from "@stimulus-components/timeago"
 import { fr } from "date-fns/locale"
 
 export default class extends Timeago {


### PR DESCRIPTION
## Problem

Five doc pages tell you to install one package and then import a different one. The `packagePath` frontmatter that drives the installation block was already correct — it's the code example underneath that still used a pre-rename name:

| Page | Example imported | Actual package |
| --- | --- | --- |
| auto-submit | `stimulus-auto-submit` | `@stimulus-components/auto-submit` 6.0.0 |
| remote-rails | `stimulus-remote-rails` | `@stimulus-components/remote-rails` 5.0.0 |
| scroll-to | `stimulus-scroll-to` | `@stimulus-components/scroll-to` 5.0.1 |
| sound | `stimulus-sound` | `@stimulus-components/sound` 2.0.1 |
| timeago | `stimulus-timeago` | `@stimulus-components/timeago` 5.0.2 |

Follow the page as written and the import fails to resolve. The worse case is the recovery path: **four of the five old names are still live on npm as abandoned majors** — `stimulus-remote-rails@4.1.0`, `stimulus-scroll-to@4.1.0`, `stimulus-sound@1.0.0`, `stimulus-timeago@4.1.0`. Anyone who installs one to make the error go away lands silently on years-old code rather than getting a clear failure. (`stimulus-auto-submit` was never published, so that one at least fails loudly.)

## Changes

The five import lines. Replacements are derived from each `components/<name>/package.json` name rather than hardcoded, so they can't drift from the source of truth.

`glow`, `places-autocomplete`, and `textarea-autogrow` deliberately keep their bare names — those three really are published unscoped, which is why #199 was the wrong call to take and stays closed.

## Verification

Cross-checked all 32 doc pages against their packages — both `packagePath` and every `import` line:

```
pages checked: 32
all doc pages agree with their package names
```

- `pnpm run lint` — pass
- `pnpm run -C docs generate` — exit 0, 116 routes prerendered
- Confirmed in the shipped HTML: `@stimulus-components/timeago` present, `from "stimulus-timeago"` occurrences: **0**

## Optional follow-up

This drifted silently for a long time because nothing checks it. The cross-check above is ~20 lines and could live as a spec so CI fails when a doc page and its package disagree. I left it out since it needs a home for repo-level (non-component) tests, which is a convention call — happy to add it if you want it.

Co-Authored-By: Claude Code <noreply@anthropic.com>