### PR TITLE
fix(auto-submit): debounce submit once instead of on every connect

### DIFF
--- a/.changeset/auto-submit-compounding-debounce.md
+++ b/.changeset/auto-submit-compounding-debounce.md
@@ -1,0 +1,7 @@
+---
+"@stimulus-components/auto-submit": patch
+---
+
+Debounce `submit` once instead of re-wrapping it on every connect.
+
+`connect()` wrapped `this.submit` in a fresh debounce every time it ran, and Stimulus reuses the controller instance when the same element leaves and re-enters the DOM (a Turbo cache restore, a form moved around the page). Every cycle added another layer, so the effective delay grew to N × `delayValue`. The wrapping now happens once, in `initialize()`.

--- a/components/auto-submit/spec/index.test.ts
+++ b/components/auto-submit/spec/index.test.ts
@@ -68,4 +68,44 @@ describe("#submit", () => {
       expect(requestSubmitSpy).toHaveBeenCalledOnce()
     })
   })
+
+  describe("when the same element reconnects", () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+
+      startStimulus()
+
+      document.body.innerHTML = `
+        <form data-controller="auto-submit">
+          <input type="checkbox" data-action="change->auto-submit#submit" />
+        </form>
+      `
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it("should keep the configured delay", async () => {
+      // Stimulus reuses the controller instance when the very same element
+      // leaves and re-enters the DOM, e.g. a Turbo cache restore, so anything
+      // wrapping `submit` in connect() would wrap the already-wrapped one.
+      const form: HTMLFormElement = document.querySelector("form")
+
+      form.remove()
+      await vi.advanceTimersByTimeAsync(0)
+
+      document.body.appendChild(form)
+      await vi.advanceTimersByTimeAsync(0)
+
+      const requestSubmitSpy = vi.spyOn(form, "requestSubmit")
+      const checkbox: HTMLInputElement = document.querySelector("input")
+
+      checkbox.click()
+
+      await vi.advanceTimersByTimeAsync(150)
+
+      expect(requestSubmitSpy).toHaveBeenCalledOnce()
+    })
+  })
 })

--- a/components/auto-submit/src/index.ts
+++ b/components/auto-submit/src/index.ts
@@ -11,14 +11,13 @@ export default class AutoSubmit extends Controller<HTMLFormElement> {
     },
   }
 
+  // Wrapping happens here rather than in connect(): Stimulus reuses the
+  // controller instance when the same element re-enters the DOM, so connect()
+  // would debounce the already-debounced submit and compound the delay.
   initialize(): void {
-    this.submit = this.submit.bind(this)
-  }
+    const submit = this.submit.bind(this)
 
-  connect(): void {
-    if (this.delayValue > 0) {
-      this.submit = debounce(this.submit, this.delayValue)
-    }
+    this.submit = this.delayValue > 0 ? debounce(submit, this.delayValue) : submit
   }
 
   submit(): void {


### PR DESCRIPTION
## The bug

`connect()` wrapped `this.submit` in a fresh debounce every time it ran:

```ts
connect(): void {
  if (this.delayValue > 0) {
    this.submit = debounce(this.submit, this.delayValue) // already debounced
  }
}
```

`initialize()` runs once per element, but `connect()` runs on **every** connect — and Stimulus reuses the controller instance when the very same element leaves and re-enters the DOM (a Turbo cache restore, a form moved around the page). So the second connect produced `debounce(debounce(submit))`, the third a third layer, and the effective delay grew to N × `delayValue`.

The added spec fails on `master`: after one detach/re-attach cycle, a change event produces no submit at all within the configured 150 ms, because the outer debounce only schedules the inner one.

## The fix

Wrap once, in `initialize()` — which is also where every other controller in the repo binds its handlers. Behaviour for the common case (a form that connects once) is unchanged, and `delay-value="0"` still submits synchronously.

Co-Authored-By: Claude Code <noreply@anthropic.com>