### PR TITLE
fix(scroll-progress): throttle scroll once instead of on every connect

### DIFF
--- a/.changeset/scroll-progress-compounding-throttle.md
+++ b/.changeset/scroll-progress-compounding-throttle.md
@@ -1,0 +1,9 @@
+---
+"@stimulus-components/scroll-progress": patch
+---
+
+Throttle `scroll` once instead of re-wrapping it on every connect.
+
+`connect()` wrapped `this.scroll` in a fresh throttle every time it ran, and Stimulus reuses the controller instance when the same element leaves and re-enters the DOM. Each cycle stacked another layer, and every layer schedules its own timer on every scroll event, so a page that reconnects the bar repeatedly ends up doing that work N times per scroll. The wrapping now happens once, in `initialize()`.
+
+This also adds the package's first spec.

--- a/components/scroll-progress/spec/index.test.ts
+++ b/components/scroll-progress/spec/index.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import ScrollProgress from "../src/index"
+
+let application: Application
+
+// jsdom lays nothing out, so the page has no scrollable height of its own.
+const stubPageHeight = (): void => {
+  Object.defineProperty(document.documentElement, "scrollHeight", { value: 2000, configurable: true })
+  Object.defineProperty(document.documentElement, "clientHeight", { value: 1000, configurable: true })
+  Object.defineProperty(window, "scrollY", { value: 0, writable: true, configurable: true })
+}
+
+const scrollTo = (y: number): void => {
+  ;(window as Window & { scrollY: number }).scrollY = y
+
+  window.dispatchEvent(new Event("scroll"))
+}
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("scroll-progress", ScrollProgress)
+}
+
+const bar = (): HTMLElement => document.querySelector("#bar")
+
+beforeEach((): void => {
+  vi.useFakeTimers()
+  stubPageHeight()
+  startStimulus()
+})
+
+afterEach((): void => {
+  document.body.innerHTML = ""
+
+  application.stop()
+  vi.useRealTimers()
+})
+
+describe("with the default throttle delay", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `<div id="bar" data-controller="scroll-progress"></div>`
+  })
+
+  it("sets the width from the current scroll position on connect", (): void => {
+    expect(bar().style.width).toBe("0%")
+  })
+
+  it("updates the width as the page scrolls", (): void => {
+    // connect() calls scroll() itself, which consumes the throttle's leading
+    // edge; let it reopen before scrolling.
+    vi.advanceTimersByTime(15)
+
+    scrollTo(500)
+
+    expect(bar().style.width).toBe("50%")
+  })
+
+  it("throttles the updates", (): void => {
+    vi.advanceTimersByTime(15)
+
+    scrollTo(500)
+    scrollTo(1000)
+
+    expect(bar().style.width).toBe("50%")
+
+    vi.advanceTimersByTime(15)
+    scrollTo(1000)
+
+    expect(bar().style.width).toBe("100%")
+  })
+
+  it("stops updating once disconnected", (): void => {
+    document.body.innerHTML = ""
+
+    scrollTo(1000)
+
+    expect(bar()).toBeNull()
+  })
+
+  it("does not stack a throttle layer when the same element reconnects", async (): Promise<void> => {
+    // Stimulus reuses the controller instance when the very same element leaves
+    // and re-enters the DOM, e.g. a Turbo cache restore.
+    const element: HTMLElement = bar()
+
+    element.remove()
+    await vi.advanceTimersByTimeAsync(0)
+
+    document.body.appendChild(element)
+    await vi.advanceTimersByTimeAsync(20)
+
+    scrollTo(500)
+
+    // One throttle layer means one pending timer. A second layer would schedule
+    // its own on every scroll event, forever.
+    expect(vi.getTimerCount()).toBe(1)
+    expect(bar().style.width).toBe("50%")
+  })
+})
+
+describe("with the throttle disabled", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div id="bar" data-controller="scroll-progress" data-scroll-progress-throttle-delay-value="0"></div>
+    `
+  })
+
+  it("updates on every scroll event", (): void => {
+    scrollTo(500)
+
+    expect(bar().style.width).toBe("50%")
+
+    scrollTo(1000)
+
+    expect(bar().style.width).toBe("100%")
+  })
+
+  it("schedules no timer at all", (): void => {
+    scrollTo(500)
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/components/scroll-progress/src/index.ts
+++ b/components/scroll-progress/src/index.ts
@@ -11,15 +11,17 @@ export default class ScrollProgress extends Controller<HTMLElement> {
     },
   }
 
+  // Throttling happens here rather than in connect(): Stimulus reuses the
+  // controller instance when the same element re-enters the DOM, so connect()
+  // would throttle the already-throttled scroll and stack a new layer — and a
+  // new timer per scroll event — on every reconnect.
   initialize(): void {
-    this.scroll = this.scroll.bind(this)
+    const scroll = this.scroll.bind(this)
+
+    this.scroll = this.throttleDelayValue > 0 ? throttle(scroll, this.throttleDelayValue) : scroll
   }
 
   connect(): void {
-    if (this.throttleDelayValue > 0) {
-      this.scroll = throttle(this.scroll, this.throttleDelayValue)
-    }
-
     window.addEventListener("scroll", this.scroll, { passive: true })
     this.scroll()
   }


### PR DESCRIPTION
Same shape as #209, in the sibling controller:

```ts
connect(): void {
  if (this.throttleDelayValue > 0) {
    this.scroll = throttle(this.scroll, this.throttleDelayValue) // already throttled
  }
  ...
}
```

`connect()` runs on every connect, and Stimulus reuses the controller instance when the very same element leaves and re-enters the DOM, so each cycle stacks another throttle layer.

**Scope, honestly:** unlike the `auto-submit` case, this one is not user-visible. Nested throttles with equal delays open and close in lockstep, so the bar still updates exactly when it did before. What piles up is the wrappers themselves and the `setTimeout` each layer schedules on every scroll event — after N reconnects, one scroll event runs N wrappers and schedules N timers. So: a leak, not a behaviour bug.

The new spec asserts that directly via `vi.getTimerCount()` after a detach/re-attach cycle; it fails on `master` and passes here. It is also the package's first spec, so it covers the basics too (width on connect, updates while scrolling, throttling, `throttle-delay-value="0"`).

One pre-existing quirk it documents rather than fixes: `connect()` calls `scroll()` itself, which consumes the throttle's leading edge, so a scroll within the first 15 ms is dropped (the shared `throttle` helper has no trailing edge).

Co-Authored-By: Claude Code <noreply@anthropic.com>