### PR TITLE
fix(prefetch): disconnect the IntersectionObserver

### DIFF
--- a/.changeset/prefetch-observer-leak.md
+++ b/.changeset/prefetch-observer-leak.md
@@ -1,0 +1,9 @@
+---
+"@stimulus-components/prefetch": patch
+---
+
+Disconnect the IntersectionObserver when the controller disconnects.
+
+`load()` kept its observer in a local `const` and only unobserved from inside the callback, so a link removed before it ever scrolled into view left the observer — and through it the controller and the detached link — alive. This mirrors the `content-loader` fix in #207.
+
+This adds the package's first spec.

--- a/components/prefetch/spec/index.test.ts
+++ b/components/prefetch/spec/index.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import Prefetch from "../src/index"
+
+let application: Application
+
+// Every observer this spec creates, so teardown can be asserted on.
+type Record = { observed: number; disconnected: boolean }
+let records: Record[]
+let callbacks: IntersectionObserverCallback[]
+
+// jsdom implements no IntersectionObserver, so a recording fake stands in. It
+// also hands back the callback, which is the only way to simulate the link
+// scrolling into view.
+const stubIntersectionObserver = (): void => {
+  records = []
+  callbacks = []
+
+  class FakeIntersectionObserver {
+    record: Record
+
+    constructor(callback: IntersectionObserverCallback) {
+      this.record = { observed: 0, disconnected: false }
+      records.push(this.record)
+      callbacks.push(callback)
+    }
+
+    observe(): void {
+      this.record.observed++
+    }
+
+    unobserve(): void {}
+
+    disconnect(): void {
+      this.record.disconnected = true
+    }
+
+    takeRecords(): [] {
+      return []
+    }
+  }
+
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
+}
+
+// jsdom reports every rel token as unsupported, which would short-circuit
+// connect() before it ever observes.
+const stubRelListSupport = (): void => {
+  vi.spyOn(DOMTokenList.prototype, "supports").mockReturnValue(true)
+}
+
+const intersect = (target: Element): void => {
+  callbacks[0]([{ isIntersecting: true, target } as IntersectionObserverEntry], {} as IntersectionObserver)
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("prefetch", Prefetch)
+}
+
+const prefetched = (): HTMLLinkElement[] => Array.from(document.head.querySelectorAll("link[rel='prefetch']"))
+
+const link = (): HTMLAnchorElement => document.querySelector("#link")
+
+const render = (): void => {
+  document.body.innerHTML = `<a id="link" href="/next" data-controller="prefetch">Next</a>`
+}
+
+beforeEach((): void => {
+  stubIntersectionObserver()
+  stubRelListSupport()
+
+  startStimulus()
+})
+
+afterEach((): void => {
+  document.body.innerHTML = ""
+  document.head.innerHTML = ""
+
+  application.stop()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("observing", () => {
+  beforeEach((): void => {
+    render()
+  })
+
+  it("observes the link without prefetching yet", (): void => {
+    expect(records.length).toBe(1)
+    expect(records[0].observed).toBe(1)
+    expect(prefetched().length).toBe(0)
+  })
+
+  it("appends the prefetch link once it intersects", (): void => {
+    intersect(link())
+
+    expect(prefetched().length).toBe(1)
+    expect(prefetched()[0].href.endsWith("/next")).toBe(true)
+    expect(prefetched()[0].as).toBe("document")
+  })
+
+  it("stops observing after it has prefetched", (): void => {
+    intersect(link())
+
+    expect(records[0].disconnected).toBe(true)
+  })
+})
+
+describe("teardown", () => {
+  beforeEach((): void => {
+    render()
+  })
+
+  it("disconnects the observer when the controller disconnects", async (): Promise<void> => {
+    expect(records[0].disconnected).toBe(false)
+
+    // A Turbo navigation removes the link before it ever scrolled into view.
+    document.body.innerHTML = ""
+    await flush()
+
+    expect(records[0].disconnected).toBe(true)
+    expect(prefetched().length).toBe(0)
+  })
+
+  it("does not accumulate observers across reconnects", async (): Promise<void> => {
+    const markup = document.body.innerHTML
+
+    document.body.innerHTML = ""
+    await flush()
+
+    document.body.innerHTML = markup
+    await flush()
+
+    expect(records.length).toBe(2)
+
+    // Only the live one is still observing; the first no longer holds the
+    // detached link or the dead controller.
+    expect(records[0].disconnected).toBe(true)
+    expect(records[1].disconnected).toBe(false)
+  })
+})
+
+describe("when prefetch is unsupported", () => {
+  beforeEach((): void => {
+    vi.spyOn(DOMTokenList.prototype, "supports").mockReturnValue(false)
+
+    render()
+  })
+
+  it("never observes", (): void => {
+    expect(records.length).toBe(0)
+    expect(prefetched().length).toBe(0)
+  })
+})

--- a/components/prefetch/src/index.ts
+++ b/components/prefetch/src/index.ts
@@ -1,6 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class Prefetch extends Controller<HTMLAnchorElement> {
+  declare observer?: IntersectionObserver
+
   initialize(): void {
     this.prefetch = this.prefetch.bind(this)
     this.load = this.load.bind(this)
@@ -12,20 +14,27 @@ export default class Prefetch extends Controller<HTMLAnchorElement> {
     this.load()
   }
 
+  disconnect(): void {
+    this.stopObserving()
+  }
+
   load(): void {
-    const observer: IntersectionObserver = new IntersectionObserver(
-      (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
-        entries.forEach((entry: IntersectionObserverEntry) => {
-          if (entry.isIntersecting) {
-            this.prefetch()
+    this.observer = new IntersectionObserver((entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry: IntersectionObserverEntry) => {
+        if (entry.isIntersecting) {
+          this.prefetch()
 
-            observer.unobserve(entry.target)
-          }
-        })
-      },
-    )
+          this.stopObserving()
+        }
+      })
+    })
 
-    observer.observe(this.element)
+    this.observer.observe(this.element)
+  }
+
+  stopObserving(): void {
+    this.observer?.disconnect()
+    this.observer = undefined
   }
 
   prefetch(): void {


### PR DESCRIPTION
Same leak as #211, in the other controller that still held its observer in a local `const`:

```ts
load(): void {
  const observer = new IntersectionObserver(...)  // local, and no disconnect()
  observer.observe(this.element)
}
```

The observer is only unobserved from inside its own callback, which never runs for a link that is removed before it scrolls into view — the common case for prefetch, which is by design attached to links far down the page. The observer then stays alive holding the detached link and the dead controller.

`stopObserving()` mirrors `content-loader/src/index.ts:107` and is called from both `disconnect()` and the callback.

This also adds the package's first spec; four of its six tests fail on `master`. Two jsdom details worth knowing for future specs here:

- `link.relList.supports("prefetch")` returns `false` in jsdom rather than throwing, so `hasPrefetch` short-circuits `connect()` unless `DOMTokenList.prototype.supports` is stubbed.
- `navigator.connection` is `undefined`, so the Save-Data and 2G guards are skipped.

Co-Authored-By: Claude Code <noreply@anthropic.com>