### PR TITLE
fix(notification,clipboard): clear the pending timeout on disconnect

### DIFF
--- a/.changeset/pending-timeouts-on-disconnect.md
+++ b/.changeset/pending-timeouts-on-disconnect.md
@@ -1,0 +1,8 @@
+---
+"@stimulus-components/notification": patch
+"@stimulus-components/clipboard": patch
+---
+
+Clear the pending timeout when the controller disconnects.
+
+Both controllers scheduled a `setTimeout` and never cleared it on teardown, so an element removed inside the window — a Turbo navigation, a notification list re-rendered — left a callback to fire against a dead controller. `notification` then ran its whole `hide()` transition on a detached element; `clipboard` wrote `innerHTML` to a detached button.

--- a/components/clipboard/spec/index.test.ts
+++ b/components/clipboard/spec/index.test.ts
@@ -88,6 +88,30 @@ describe("#copy", () => {
   })
 })
 
+describe("when removed while showing the success content", () => {
+  it("does not fire the pending timeout", async (): Promise<void> => {
+    vi.useFakeTimers()
+
+    button().click()
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(button().innerHTML).toBe("Copied!")
+    expect(vi.getTimerCount()).toBe(1)
+
+    // A Turbo navigation drops the button before the revert is due.
+    const detached: HTMLButtonElement = button()
+    document.body.innerHTML = ""
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(vi.getTimerCount()).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(detached.innerHTML).toBe("Copied!")
+  })
+})
+
 describe("with a custom success duration", () => {
   beforeEach((): void => {
     document.body.innerHTML = `

--- a/components/clipboard/src/index.ts
+++ b/components/clipboard/src/index.ts
@@ -24,6 +24,10 @@ export default class Clipboard extends Controller {
     this.originalContent = this.buttonTarget.innerHTML
   }
 
+  disconnect(): void {
+    clearTimeout(this.timeout)
+  }
+
   copy(event: Event): void {
     event.preventDefault()
 

--- a/components/notification/spec/index.test.ts
+++ b/components/notification/spec/index.test.ts
@@ -60,6 +60,34 @@ describe("when visible by default", () => {
   )
 })
 
+describe("when removed before the delay elapses", () => {
+  it("does not fire the pending timeout", async (): Promise<void> => {
+    const hide = vi.spyOn(Notification.prototype, "hide")
+
+    // The spy has to be in place before initialize() binds hide().
+    document.body.innerHTML = `
+      <div id="notification" data-controller="notification" data-notification-delay-value="${DELAY}" class="hidden">
+        <p>This alert will magically disappear!</p>
+      </div>
+    `
+
+    // Stimulus connects off a MutationObserver, so the timeout only exists
+    // after a turn of the event loop.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(notification().classList.contains("hidden")).toBe(false)
+
+    // A Turbo navigation drops the notification before its delay is up.
+    document.body.innerHTML = ""
+
+    await new Promise((resolve) => setTimeout(resolve, DELAY * 5))
+
+    expect(hide).not.toHaveBeenCalled()
+
+    hide.mockRestore()
+  })
+})
+
 describe("when hidden by default", () => {
   beforeEach((): void => {
     document.body.innerHTML = `

--- a/components/notification/src/index.ts
+++ b/components/notification/src/index.ts
@@ -32,6 +32,10 @@ export default class Notification extends Controller {
     }
   }
 
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+
   show() {
     this.enter()
 


### PR DESCRIPTION
Two controllers schedule a `setTimeout` and never clear it:

- `notification` — `show()` schedules `hide()` at `delayValue` (default **3s**) and the controller has no `disconnect()` at all. Navigate away inside those 3 seconds and `hide()` runs on a dead controller: it awaits `leave()` from `stimulus-use`, driving a transition on a detached element, then calls `remove()` on it.
- `clipboard` — `copied()` schedules the revert at `successDurationValue` (default 2s), which then writes `innerHTML` to a detached button.

Neither throws, which is why they went unnoticed; both are just work done on nodes nobody can see.

One line each. Both packages already had specs, so each gets a regression test that fails on `master`.

Worth noting for anyone writing similar specs: the notification test has to wait a turn of the event loop after inserting the markup before removing it. Stimulus connects off a `MutationObserver`, so inserting and removing in the same tick means the controller never connects and the test passes vacuously — which is exactly what the first draft of it did.

Co-Authored-By: Claude Code <noreply@anthropic.com>