### PR TITLE
chore(timeago): type refreshTimer instead of suppressing the error

### DIFF
--- a/.changeset/timeago-timer-type.md
+++ b/.changeset/timeago-timer-type.md
@@ -1,0 +1,7 @@
+---
+"@stimulus-components/timeago": patch
+---
+
+Type `refreshTimer` as `ReturnType<typeof setInterval>` and drop the `@ts-ignore`.
+
+The field was declared `number`, which only matches the DOM `setInterval`, so the assignment needed a suppression to compile against Node's typings. The inferred type works under both, and the suppression is gone.

--- a/components/timeago/src/index.ts
+++ b/components/timeago/src/index.ts
@@ -4,7 +4,7 @@ import { formatDistanceToNow } from "date-fns"
 
 export default class Timeago extends Controller<HTMLTimeElement> {
   declare isValid: boolean
-  declare refreshTimer: number
+  declare refreshTimer: ReturnType<typeof setInterval>
   declare locale: Pick<Locale, "formatDistance">
 
   declare hasRefreshIntervalValue: boolean
@@ -58,7 +58,6 @@ export default class Timeago extends Controller<HTMLTimeElement> {
   }
 
   startRefreshing(): void {
-    // @ts-ignore
     this.refreshTimer = setInterval(() => {
       this.load()
     }, this.refreshIntervalValue)


### PR DESCRIPTION
```ts
declare refreshTimer: number
...
// @ts-ignore
this.refreshTimer = setInterval(...)
```

`number` only matches the DOM `setInterval`; the root type-check resolves Node's, which returns `NodeJS.Timeout` — hence the suppression. `ReturnType<typeof setInterval>` is correct under both, which is what CLAUDE.md asks for and what `content-loader/src/index.ts:4` already does.

Verified through both type-check paths, since they disagree here:

- `pnpm run lint` (root `tsc`, Node typings) ✓
- `pnpm -C components/timeago run build` (declaration emit, DOM typings) ✓

The emitted `dist/types/index.d.ts` now carries `refreshTimer: ReturnType<typeof setInterval>`, which resolves against whichever lib the consumer compiles with, rather than hard-coding `number`.

No runtime change.

Co-Authored-By: Claude Code <noreply@anthropic.com>