### PR TITLE
chore: replace the remaining type suppressions with real types

### DIFF
--- a/.changeset/replace-type-suppressions.md
+++ b/.changeset/replace-type-suppressions.md
@@ -1,0 +1,10 @@
+---
+"@stimulus-components/checkbox-select-all": patch
+"@stimulus-components/rails-nested-form": patch
+"@stimulus-components/dropdown": patch
+"@stimulus-components/popover": patch
+---
+
+Replace the remaining `@ts-expect-error`/`@ts-ignore` comments with real types.
+
+`EventTarget` casts stand in for the suppressions in `checkbox-select-all`, `dropdown` and `popover`. In `rails-nested-form` and `popover` the honest types surfaced a real `null` case — a remove button outside any wrapper, and a `currentTarget` that has already been cleared — which now returns early instead of raising a `TypeError`.

--- a/components/checkbox-select-all/src/index.ts
+++ b/components/checkbox-select-all/src/index.ts
@@ -47,9 +47,10 @@ export default class CheckboxSelectAll extends Controller {
   toggle(e: Event): void {
     e.preventDefault()
 
+    const { checked } = e.target as HTMLInputElement
+
     this.checkboxTargets.forEach((checkbox) => {
-      // @ts-expect-error
-      checkbox.checked = e.target.checked
+      checkbox.checked = checked
       this.triggerInputEvent(checkbox)
     })
   }

--- a/components/dropdown/src/index.ts
+++ b/components/dropdown/src/index.ts
@@ -20,8 +20,7 @@ export default class Dropdown extends Controller {
   }
 
   hide(event: Event): void {
-    // @ts-expect-error
-    if (!this.element.contains(event.target) && !this.menuTarget.classList.contains("hidden")) {
+    if (!this.element.contains(event.target as Node) && !this.menuTarget.classList.contains("hidden")) {
       this.leave()
     }
   }

--- a/components/popover/src/index.ts
+++ b/components/popover/src/index.ts
@@ -16,7 +16,7 @@ export default class Popover extends Controller {
 
   async show(event: Event): Promise<void> {
     // Temporally variable to prevent `event.currentTarget` to being null.
-    const element = event.currentTarget
+    const element = event.currentTarget as HTMLElement | null
 
     let content: string | undefined
 
@@ -26,10 +26,9 @@ export default class Popover extends Controller {
       content = await this.fetch()
     }
 
-    if (!content) return
+    if (!content || !element) return
 
     const fragment: DocumentFragment = document.createRange().createContextualFragment(content)
-    // @ts-ignore
     element.appendChild(fragment)
   }
 

--- a/components/rails-nested-form/spec/index.test.ts
+++ b/components/rails-nested-form/spec/index.test.ts
@@ -71,3 +71,55 @@ describe("#nestedForm", (): void => {
     })
   })
 })
+
+describe("#remove", (): void => {
+  let errors: string[]
+
+  beforeEach((): void => {
+    startStimulus()
+
+    errors = []
+    application.handleError = (error: Error): void => {
+      errors.push(error.message)
+    }
+
+    document.body.innerHTML = `
+      <form data-controller="nested-form">
+        <div id="new" class="nested-form-wrapper" data-new-record="true">
+          <button type="button" data-action="nested-form#remove">Remove new</button>
+        </div>
+
+        <div id="persisted" class="nested-form-wrapper" data-new-record="false">
+          <input type="hidden" name="todos[0][_destroy]" value="0" />
+          <button type="button" data-action="nested-form#remove">Remove persisted</button>
+        </div>
+
+        <button id="stray" type="button" data-action="nested-form#remove">Remove nothing</button>
+      </form>
+    `
+  })
+
+  it("removes a new record outright", (): void => {
+    document.querySelector<HTMLButtonElement>("#new button").click()
+
+    expect(document.querySelector("#new")).toBeNull()
+  })
+
+  it("hides a persisted record and flags it for destruction", (): void => {
+    document.querySelector<HTMLButtonElement>("#persisted button").click()
+
+    const wrapper: HTMLElement = document.querySelector("#persisted")
+
+    expect(wrapper).not.toBeNull()
+    expect(wrapper.style.display).toBe("none")
+    expect(wrapper.querySelector<HTMLInputElement>("input").value).toBe("1")
+  })
+
+  it("does nothing when the button sits outside any wrapper", (): void => {
+    document.querySelector<HTMLButtonElement>("#stray").click()
+
+    expect(document.querySelector("#new")).not.toBeNull()
+    expect(document.querySelector("#persisted")).not.toBeNull()
+    expect(errors).toEqual([])
+  })
+})

--- a/components/rails-nested-form/src/index.ts
+++ b/components/rails-nested-form/src/index.ts
@@ -26,8 +26,9 @@ export default class RailsNestedForm extends Controller {
   remove(e: Event): void {
     e.preventDefault()
 
-    // @ts-expect-error
-    const wrapper: HTMLElement = e.target.closest(this.wrapperSelectorValue)
+    const wrapper = (e.target as HTMLElement).closest<HTMLElement>(this.wrapperSelectorValue)
+
+    if (!wrapper) return
 
     if (wrapper.dataset.newRecord === "true") {
       wrapper.remove()


### PR DESCRIPTION
Four suppressions in `src/`, all standing in for an `EventTarget` cast:

| File | Was | Now |
| --- | --- | --- |
| `checkbox-select-all:51` | `@ts-expect-error` on `e.target.checked` | `const { checked } = e.target as HTMLInputElement`, hoisted out of the loop |
| `dropdown:23` | `@ts-expect-error` on `contains(event.target)` | `event.target as Node` |
| `popover:32` | `@ts-ignore` on `element.appendChild` | `event.currentTarget as HTMLElement \| null` |
| `rails-nested-form:29` | `@ts-expect-error` on `e.target.closest(...)` | `(e.target as HTMLElement).closest<HTMLElement>(...)` |

**Two are not purely cosmetic.** Once the casts are honest, `strict` points at a `null` neither call site handled:

- `rails-nested-form#remove` — `closest()` returns `null` for a remove button that is not inside `wrapperSelectorValue` (a misconfigured selector, a button moved out of its wrapper). Reading `wrapper.dataset` then throws a `TypeError`.
- `popover#show` — the `currentTarget as HTMLElement` cast would be a lie: the whole reason that variable exists, per the comment above it, is that `currentTarget` is cleared once the handler yields, and `show()` awaits a fetch.

Both now return early rather than raising. That is a behaviour change, small and in the direction of not throwing, so worth an explicit look during review.

`rails-nested-form#remove` had no spec at all, so this adds three: the new-record path, the persisted `_destroy` path, and the stray-button guard (which fails on `master` with `Cannot read properties of null`).

Left alone: the `@ts-expect-error` in `rails-nested-form/spec/index.test.ts:58`, which mocks the `CustomEvent` constructor. Typing that faithfully costs more than the suppression saves.

No other runtime change; all four packages build clean.

Co-Authored-By: Claude Code <noreply@anthropic.com>