### PR TITLE
chore(scroll-to): use scrollY instead of the deprecated pageYOffset

### DIFF
--- a/.changeset/scroll-to-scrolly.md
+++ b/.changeset/scroll-to-scrolly.md
@@ -1,0 +1,7 @@
+---
+"@stimulus-components/scroll-to": patch
+---
+
+Use `window.scrollY` instead of the deprecated `window.pageYOffset`.
+
+The two are defined as aliases, so this is a rename with no behaviour change.

--- a/components/scroll-to/spec/index.test.ts
+++ b/components/scroll-to/spec/index.test.ts
@@ -15,7 +15,7 @@ const startStimulus = (): void => {
 }
 
 // jsdom does not implement window.scrollTo, so stub it to observe the call.
-// getBoundingClientRect() and pageYOffset are both 0 here, which makes the
+// getBoundingClientRect() and scrollY are both 0 here, which makes the
 // expected top exactly the negated offset.
 const stubScrollTo = (): void => {
   scrollTo = vi.fn()
@@ -56,6 +56,18 @@ describe("#scroll", () => {
     link().dispatchEvent(event)
 
     expect(event.defaultPrevented).toBe(true)
+  })
+
+  it("adds the current scroll position to the element's viewport-relative top", (): void => {
+    const target: HTMLElement = document.querySelector("#target")
+
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue({ top: 100 } as DOMRect)
+    vi.stubGlobal("scrollY", 300)
+
+    link().click()
+
+    // 100 below the fold, 300 already scrolled, less the default 10 offset.
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 390 }))
   })
 })
 

--- a/components/scroll-to/src/index.ts
+++ b/components/scroll-to/src/index.ts
@@ -40,7 +40,7 @@ export default class ScrollTo extends Controller<HTMLAnchorElement> {
       return
     }
 
-    const elementPosition: number = target.getBoundingClientRect().top + window.pageYOffset
+    const elementPosition: number = target.getBoundingClientRect().top + window.scrollY
     const offsetPosition: number = elementPosition - this.offset
 
     window.scrollTo({


### PR DESCRIPTION
```ts
const elementPosition = target.getBoundingClientRect().top + window.pageYOffset
```

`pageYOffset` is specified as an alias of `scrollY` and is marked deprecated in the CSSOM View spec. Pure rename, no behaviour change.

The existing specs could not have caught a bad rename: jsdom reports `0` for both `getBoundingClientRect().top` and the scroll position, so every expectation reduced to the negated offset — as the comment at the top of the spec says outright. This adds one test that stubs both to non-zero values (`100` below the fold, `300` already scrolled, default `10` offset → `top: 390`), so the term actually carries weight.

That test also had to use `vi.stubGlobal("scrollY", …)` rather than `Object.defineProperty`: the suite's `afterEach` calls `unstubAllGlobals()` but nothing undoes a raw `defineProperty`, so a stubbed scroll position would leak into the offset tests that run after it.

Co-Authored-By: Claude Code <noreply@anthropic.com>