### PR TITLE
feat(character-counter): add a count-unit value for code points and graphemes

### DIFF
--- a/.changeset/rotten-parrots-smoke.md
+++ b/.changeset/rotten-parrots-smoke.md
@@ -1,0 +1,5 @@
+---
+"@stimulus-components/character-counter": minor
+---
+
+Add a `count-unit` value to choose how characters are counted: `code-units` (default, unchanged behaviour), `code-points`, or `graphemes` so that composed emojis count as a single character.

--- a/components/character-counter/spec/index.test.ts
+++ b/components/character-counter/spec/index.test.ts
@@ -62,4 +62,48 @@ describe("#update", () => {
       expect(content.innerHTML).toBe("100")
     })
   })
+
+  describe("with multibyte characters", () => {
+    // A ZWJ sequence: 11 code units, 7 code points, 1 grapheme.
+    const family = "👨‍👩‍👧‍👦"
+
+    const render = async (countUnit?: string): Promise<HTMLElement> => {
+      startStimulus()
+
+      const countUnitAttribute = countUnit ? `data-character-counter-count-unit-value="${countUnit}"` : ""
+
+      document.body.innerHTML = `
+      <div data-controller="character-counter" ${countUnitAttribute}>
+        <textarea
+          data-character-counter-target="input"
+        >${family}</textarea>
+
+        <strong data-character-counter-target="counter"></strong>
+      </div>
+    `
+
+      // Stimulus connects controllers from a MutationObserver callback.
+      await new Promise((resolve): void => {
+        setTimeout(resolve, 0)
+      })
+
+      return document.querySelector<HTMLElement>('[data-character-counter-target="counter"]')
+    }
+
+    it("should count code units by default", async (): Promise<void> => {
+      expect((await render()).innerHTML).toBe("11")
+    })
+
+    it("should count code points", async (): Promise<void> => {
+      expect((await render("code-points")).innerHTML).toBe("7")
+    })
+
+    it("should count graphemes", async (): Promise<void> => {
+      expect((await render("graphemes")).innerHTML).toBe("1")
+    })
+
+    it("should fall back to code units on an unknown count unit", async (): Promise<void> => {
+      expect((await render("bytes")).innerHTML).toBe("11")
+    })
+  })
 })

--- a/components/character-counter/src/index.ts
+++ b/components/character-counter/src/index.ts
@@ -1,24 +1,62 @@
 import { Controller } from "@hotwired/stimulus"
 
+const COUNT_UNITS = ["code-units", "code-points", "graphemes"] as const
+
+type CountUnit = (typeof COUNT_UNITS)[number]
+
+// Intl.Segmenter is not part of the `es6` lib this repo compiles against, so declare the bits we use.
+interface GraphemeSegmenter {
+  segment(input: string): Iterable<unknown>
+}
+
+type SegmenterConstructor = new (
+  locales?: string | string[],
+  options?: { granularity: "grapheme" },
+) => GraphemeSegmenter
+
 export default class CharacterCounter extends Controller {
   declare readonly counterTarget: HTMLElement
   declare readonly inputTarget: HTMLInputElement
   declare readonly hasCountdownValue: boolean
+  declare readonly countUnitValue: CountUnit
+  declare segmenter?: GraphemeSegmenter
 
   static targets = ["input", "counter"]
-  static values = { countdown: Boolean }
+  static values = {
+    countdown: Boolean,
+    countUnit: { type: String, default: "code-units" },
+  }
 
   initialize(): void {
     this.update = this.update.bind(this)
   }
 
   connect(): void {
+    if (COUNT_UNITS.indexOf(this.countUnitValue) === -1) {
+      console.error(
+        `[stimulus-character-counter] Unknown count unit: ${this.countUnitValue}. Valid units are: ${COUNT_UNITS.join(", ")}. Falling back to code-units.`,
+      )
+    }
+
+    if (this.countUnitValue === "graphemes") {
+      const Segmenter = (Intl as unknown as { Segmenter?: SegmenterConstructor }).Segmenter
+
+      if (Segmenter) {
+        this.segmenter = new Segmenter(undefined, { granularity: "grapheme" })
+      } else {
+        console.error(
+          "[stimulus-character-counter] Intl.Segmenter is not supported by this browser. Falling back to code-points.",
+        )
+      }
+    }
+
     this.update()
     this.inputTarget.addEventListener("input", this.update)
   }
 
   disconnect(): void {
     this.inputTarget.removeEventListener("input", this.update)
+    this.segmenter = undefined
   }
 
   update(): void {
@@ -26,7 +64,7 @@ export default class CharacterCounter extends Controller {
   }
 
   get count(): number {
-    let value: number = this.inputTarget.value.length
+    let value: number = this.inputLength
 
     if (this.hasCountdownValue) {
       if (this.maxLength < 0) {
@@ -39,6 +77,19 @@ export default class CharacterCounter extends Controller {
     }
 
     return value
+  }
+
+  get inputLength(): number {
+    const value = this.inputTarget.value
+
+    switch (this.countUnitValue) {
+      case "graphemes":
+        return this.segmenter ? [...this.segmenter.segment(value)].length : [...value].length
+      case "code-points":
+        return [...value].length
+      default:
+        return value.length
+    }
   }
 
   get maxLength(): number {

--- a/docs/content/docs/stimulus-character-counter.md
+++ b/docs/content/docs/stimulus-character-counter.md
@@ -47,11 +47,31 @@ You can use it in countdown mode, add the correct value and a `maxlength` attrib
 
 ::
 
+By default, characters are counted as UTF-16 code units, the same unit the browser uses to enforce `maxlength`. Emojis and other multibyte characters then count as more than one character. Use the count unit value to count Unicode code points, or graphemes so that a composed emoji such as 👨‍👩‍👧‍👦 counts as a single character:
+
+::code-block{tabName="app/views/index.html"}
+
+```html
+<div data-controller="character-counter" data-character-counter-count-unit-value="graphemes">
+  <textarea data-character-counter-target="input"></textarea>
+
+  <p>
+    There are
+    <strong data-character-counter-target="counter"></strong> characters in this textarea.
+  </p>
+</div>
+```
+
+::
+
+Grapheme counting relies on [`Intl.Segmenter`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter); on browsers without it, the controller falls back to counting code points. Note that `maxlength` is still enforced by the browser in code units, so in countdown mode a counter using another unit will not reach zero at the same time as the browser stops accepting input.
+
 ## Configuration
 
-| Attribute                                | Default     | Description                  | Optional |
-| ---------------------------------------- | ----------- | ---------------------------- | -------- |
-| `data-character-counter-countdown-value` | `undefined` | Activate the countdown mode. | ✅       |
+| Attribute                                 | Default      | Description                                                           | Optional |
+| ----------------------------------------- | ------------ | --------------------------------------------------------------------- | -------- |
+| `data-character-counter-countdown-value`  | `undefined`  | Activate the countdown mode.                                          | ✅       |
+| `data-character-counter-count-unit-value` | `code-units` | How characters are counted: `code-units`, `code-points`, `graphemes`. | ✅       |
 
 ## Extending Controller
 


### PR DESCRIPTION
Closes #120.

The counter uses `String#length`, which counts UTF-16 code units, so emojis and other multibyte characters count as more than one character — `😍` counts as 2, and a composed ZWJ sequence like `👨‍👩‍👧‍👦` counts as 11.

Rather than swapping the counting method outright, this adds a `count-unit` value, as suggested in the issue and in @mactunechy's comment, so the default behaviour is unchanged:

| Unit | `👨‍👩‍👧‍👦` counts as | Notes |
| --- | --- | --- |
| `code-units` (default) | 11 | `String#length`, current behaviour — the same unit the browser enforces `maxlength` in |
| `code-points` | 7 | `[...value].length` |
| `graphemes` | 1 | `Intl.Segmenter` |

```html
<div data-controller="character-counter" data-character-counter-count-unit-value="graphemes">
  <textarea data-character-counter-target="input"></textarea>
  <strong data-character-counter-target="counter"></strong>
</div>
```

### Notes

- The segmenter is created in `connect()` only when the grapheme unit is used, and cleared in `disconnect()`.
- Counting moved into a public `inputLength` getter; `count` keeps the countdown logic on top of it.
- Two guards in the existing `console.error` style: an unknown unit falls back to code units, and a missing `Intl.Segmenter` (older Safari/Firefox) falls back to code points.
- `Intl.Segmenter` is not in the `es6` lib this repo compiles against, so its constructor is declared locally rather than widening `lib` repo-wide or reaching for `@ts-expect-error`.
- `maxlength` is still enforced by the browser in code units, so in countdown mode a non-default unit will not reach zero exactly when the browser stops accepting input. This is documented rather than worked around — fixing it properly means enforcing the limit in JS, which is closer to #136.
- I did not adopt the `.trim()` from the snippet in the issue, since it would silently change counts for everyone.

### Tests

Four specs covering each unit and the unknown-unit fallback, using a ZWJ family emoji. `pnpm run lint`, `pnpm run test` (97 passed), and `pnpm -C components/character-counter run build` all pass.

Docs page and a changeset are included.

Co-Authored-By: Claude Code <noreply@anthropic.com>