### PR TITLE
[carousel] update swiper to ^14

### DIFF
--- a/.changeset/carousel-swiper-14.md
+++ b/.changeset/carousel-swiper-14.md
@@ -1,0 +1,13 @@
+---
+"@stimulus-components/carousel": major
+---
+
+Update the `swiper` dependency from `^11.0.6` to `^14.0.0`.
+
+Swiper 11 is affected by [GHSA-hmx5-qpq5-p643](https://github.com/advisories/GHSA-hmx5-qpq5-p643), fixed in Swiper 12.1. The old `^11.0.6` range held consumers on a vulnerable version and blocked them from upgrading Swiper in their own apps.
+
+The controller itself is unchanged. Swiper 14 is a TypeScript rewrite with no runtime behaviour changes — every option, event, and method signature still behaves as it did in 11, and both `swiper/bundle` and `swiper/types` remain in its `exports` map. The CSS class names (`swiper`, `swiper-wrapper`, `swiper-slide`, …) are the same, so no markup needs to change.
+
+This is a **major** bump because `swiper` is a runtime dependency and Swiper 14 raises the browser baseline to Chrome/Edge 110+, Safari 16.4+ (iOS 16.4+), and Firefox 110+. Code paths for older browsers were removed upstream. If you need to support browsers below that baseline, stay on `@stimulus-components/carousel@6`, which keeps Swiper 11.
+
+Note that Swiper has no version 13; upstream skipped it, so 11 → 14 spans two majors.

--- a/components/carousel/package.json
+++ b/components/carousel/package.json
@@ -45,7 +45,7 @@
     "@hotwired/stimulus": "^3"
   },
   "dependencies": {
-    "swiper": "^11.0.6"
+    "swiper": "^14.0.0"
   },
   "files": [
     "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^3
         version: 3.2.2
       swiper:
-        specifier: ^11.0.6
-        version: 11.2.10
+        specifier: ^14.0.0
+        version: 14.1.0
 
   components/character-counter:
     dependencies:
@@ -6272,8 +6272,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  swiper@11.2.10:
-    resolution: {integrity: sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==}
+  swiper@14.1.0:
+    resolution: {integrity: sha512-ppit/AqmGvThKlXy4I1/9N/gEyb9s/BDHWciWNeIxbfteFKUhPQXrYuOMKszomXKd9WiLd+/0vKdPHW+0N0mhA==}
     engines: {node: '>= 4.7.0'}
 
   symbol-tree@3.2.4:
@@ -13869,7 +13869,7 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.4.4
 
-  swiper@11.2.10: {}
+  swiper@14.1.0: {}
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
Updates the `swiper` dependency in `@stimulus-components/carousel` from `^11.0.6` to `^14.0.0`, with the lockfile and a changeset.

Supersedes #170 and closes #171. That PR proposed `^12.0.0`, which has two problems: `^12.0.0` still permits the vulnerable 12.0.x (the fix landed in 12.1), and it would leave consumers unable to move to 14. Thanks to @louis-celier-nrj for raising it.

## Why

Swiper 11 is affected by [GHSA-hmx5-qpq5-p643](https://github.com/advisories/GHSA-hmx5-qpq5-p643), fixed in Swiper 12.1. Because `swiper/bundle` is marked `external` in `components/carousel/vite.config.mts`, swiper is never inlined into our build — the range in `package.json` decides which version consumers resolve. So the old range held them on a vulnerable version and blocked their own upgrades.

Note that Swiper has no version 13; upstream skipped it, so 11 → 14 spans two majors.

## The controller is unchanged

Swiper 14 is a ground-up TypeScript rewrite, but [its changelog](https://github.com/nolimits4web/swiper/blob/master/CHANGELOG.md) states that upgrading from 12 requires no code changes and that there are no runtime behaviour changes. Verified for our usage:

- `swiper/bundle` (default export) and `swiper/types` (`SwiperOptions`) are both still in the v14 `exports` map, so `src/index.ts` compiles as-is.
- The CSS class names — `swiper`, `swiper-wrapper`, `swiper-slide`, `swiper-button-next`, `swiper-pagination` — are unchanged in `swiper-bundle.css`, so the docs page and the demo need no edits.

## Breaking change

Released as a **major** (`6.0.0` → `7.0.0`). Swiper 14 raises the browser baseline to **Chrome/Edge 110+, Safari 16.4+ (iOS 16.4+), and Firefox 110+**, and upstream removed the code paths for older browsers. Since swiper is a runtime dependency, that baseline reaches consumers. Anyone who must support older browsers can stay on `@stimulus-components/carousel@6`, which keeps Swiper 11.

## Verification

All four CI steps were run locally against swiper 14.1.0:

- `pnpm run lint` — clean (`tsc --noEmit` + ESLint)
- `pnpm run test` — 21 files, 128 tests passed
- `pnpm run build:components` — clean; carousel emits `dist/stimulus-carousel.mjs`, `.umd.js`, and `dist/types/index.d.ts`, matching the `types` field
- `pnpm run -C docs generate` — 116 routes prerendered; the `stimulus-carousel` page builds and swiper 14 plus its CSS land in the output bundle

Additionally, a runtime smoke test in jsdom confirmed the controller against swiper 14: `connect()` builds the instance, the `options` value merges through (`direction: "vertical"` applied), slides are detected, and removing the element leaves `swiper.destroyed === true`.

Co-Authored-By: Claude Code <noreply@anthropic.com>