### PR TITLE
feat(checkbox-select-all): ignore disabled checkboxes

### DIFF
--- a/.changeset/checkbox-select-all-disabled.md
+++ b/.changeset/checkbox-select-all-disabled.md
@@ -1,0 +1,19 @@
+---
+"@stimulus-components/checkbox-select-all": minor
+---
+
+Never toggle disabled checkboxes, and add a `ignoreDisabled` value to control how they count in the indeterminate state.
+
+`toggle()` wrote `checked` on every checkbox target, including the disabled ones. A user cannot change a disabled checkbox and the browser does not submit it, so the `checkboxAll` target must not change it either. It now toggles only the enabled checkbox targets. Closes #110, and ports stimulus-components/stimulus-checkbox-select-all#10.
+
+That leaves the question raised in the review of that PR: what the `checkboxAll` target must show when a disabled checkbox keeps a different state. It is now an option, like `disableIndeterminate`:
+
+- by default, the disabled checkboxes still count, so the `checkboxAll` target stays indeterminate after a "Select All" click when one disabled checkbox is unchecked;
+- with `data-checkbox-select-all-ignore-disabled-value="true"`, only the checkboxes that the `checkboxAll` target can change are counted, and the indeterminate state disappears when all the enabled checkboxes are checked.
+
+Two related changes make this work:
+
+- `toggle()` now calls `refresh()`. The checkbox targets do not emit a `change` event when the controller writes their `checked` property, so the state of the `checkboxAll` target was never computed again after a click. Without disabled checkboxes this changes nothing, because the recomputed state matches the state the browser already applied.
+- The `checked` property of the `checkboxAll` target now counts only the enabled checkbox targets, so a click always toggles them. Counting the disabled ones there made the control show a selection it could not clear: with all the enabled checkboxes unchecked and one disabled checkbox checked, every click was read as "deselect all" and the enabled checkboxes could never be checked again. The `indeterminate` property still counts the disabled checkboxes, unless `ignoreDisabled` is set.
+
+Adds `enabled` and `disabled` getters, next to `checked` and `unchecked`.

--- a/components/checkbox-select-all/index.html
+++ b/components/checkbox-select-all/index.html
@@ -57,6 +57,68 @@
       </section>
 
       <section class="mt-16">
+        <form data-controller="checkbox-select-all">
+          <table>
+            <tbody>
+              <tr>
+                <td class="block">
+                  <label>
+                    <input type="checkbox" data-checkbox-select-all-target="checkboxAll" />
+                    <span>Select All / Deselect All, with a disabled checkbox</span>
+                  </label>
+                </td>
+
+                <td class="block">
+                  <label>
+                    <input type="checkbox" data-checkbox-select-all-target="checkbox" />
+                    <span>Team 1</span>
+                  </label>
+                </td>
+
+                <td class="block">
+                  <label>
+                    <input type="checkbox" data-checkbox-select-all-target="checkbox" disabled />
+                    <span>Team 2, disabled</span>
+                  </label>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </form>
+      </section>
+
+      <section class="mt-16">
+        <form data-controller="checkbox-select-all" data-checkbox-select-all-ignore-disabled-value="true">
+          <table>
+            <tbody>
+              <tr>
+                <td class="block">
+                  <label>
+                    <input type="checkbox" data-checkbox-select-all-target="checkboxAll" />
+                    <span>Select All / Deselect All, ignoring the disabled checkbox</span>
+                  </label>
+                </td>
+
+                <td class="block">
+                  <label>
+                    <input type="checkbox" data-checkbox-select-all-target="checkbox" />
+                    <span>Team 1</span>
+                  </label>
+                </td>
+
+                <td class="block">
+                  <label>
+                    <input type="checkbox" data-checkbox-select-all-target="checkbox" disabled />
+                    <span>Team 2, disabled</span>
+                  </label>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </form>
+      </section>
+
+      <section class="mt-16">
         <form data-controller="checkbox-select-all" data-checkbox-select-all-disable-indeterminate-value="true">
           <table>
             <tbody>

--- a/components/checkbox-select-all/spec/index.test.ts
+++ b/components/checkbox-select-all/spec/index.test.ts
@@ -89,6 +89,115 @@ describe("without a checkboxAll target", () => {
   })
 })
 
+describe("with disabled checkboxes", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+    <form data-controller="checkbox-select-all">
+      <input id="checkbox-select-all" type="checkbox" data-checkbox-select-all-target="checkboxAll" />
+      <input type="checkbox" data-checkbox-select-all-target="checkbox" />
+      <input type="checkbox" data-checkbox-select-all-target="checkbox" checked="checked" />
+      <input id="disabled-unchecked" type="checkbox" data-checkbox-select-all-target="checkbox" disabled="disabled" />
+      <input
+        id="disabled-checked"
+        type="checkbox"
+        data-checkbox-select-all-target="checkbox"
+        checked="checked"
+        disabled="disabled"
+      />
+    </form>
+  `
+  })
+
+  it("does not check the disabled checkboxes", (): void => {
+    const toggleCheckbox: HTMLInputElement = document.querySelector("#checkbox-select-all")
+    const disabledUnchecked: HTMLInputElement = document.querySelector("#disabled-unchecked")
+
+    // Uncheck all
+    toggleCheckbox.click()
+
+    // Check all
+    toggleCheckbox.click()
+
+    expect(disabledUnchecked.checked).toBe(false)
+    expect(document.querySelectorAll("[data-checkbox-select-all-target='checkbox']:checked").length).toBe(3)
+  })
+
+  it("does not uncheck the disabled checkboxes", (): void => {
+    const toggleCheckbox: HTMLInputElement = document.querySelector("#checkbox-select-all")
+    const disabledChecked: HTMLInputElement = document.querySelector("#disabled-checked")
+
+    // Uncheck all
+    toggleCheckbox.click()
+
+    expect(disabledChecked.checked).toBe(true)
+    expect(document.querySelectorAll("[data-checkbox-select-all-target='checkbox']:checked").length).toBe(1)
+  })
+
+  it("stays unchecked when only a disabled checkbox is checked", (): void => {
+    const toggleCheckbox: HTMLInputElement = document.querySelector("#checkbox-select-all")
+
+    // Uncheck all
+    toggleCheckbox.click()
+
+    // The next click must check the enabled checkboxes again, and not uncheck them.
+    expect(toggleCheckbox.checked).toBe(false)
+    expect(toggleCheckbox.indeterminate).toBe(true)
+  })
+
+  it("keeps the indeterminate state when a disabled checkbox stays unchecked", (): void => {
+    const toggleCheckbox: HTMLInputElement = document.querySelector("#checkbox-select-all")
+
+    // Uncheck all
+    toggleCheckbox.click()
+
+    // Check all
+    toggleCheckbox.click()
+
+    expect(toggleCheckbox.checked).toBe(true)
+    expect(toggleCheckbox.indeterminate).toBe(true)
+  })
+})
+
+describe("when ignoring the disabled checkboxes", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+    <form data-controller="checkbox-select-all" data-checkbox-select-all-ignore-disabled-value="true">
+      <input id="checkbox-select-all" type="checkbox" data-checkbox-select-all-target="checkboxAll" />
+      <input type="checkbox" data-checkbox-select-all-target="checkbox" />
+      <input type="checkbox" data-checkbox-select-all-target="checkbox" checked="checked" />
+      <input type="checkbox" data-checkbox-select-all-target="checkbox" disabled="disabled" />
+    </form>
+  `
+  })
+
+  it("removes the indeterminate state when all the enabled checkboxes are checked", (): void => {
+    const toggleCheckbox: HTMLInputElement = document.querySelector("#checkbox-select-all")
+
+    // Uncheck all
+    toggleCheckbox.click()
+
+    // Check all
+    toggleCheckbox.click()
+
+    expect(toggleCheckbox.checked).toBe(true)
+    expect(toggleCheckbox.indeterminate).toBe(false)
+  })
+
+  it("stays unchecked when all the checkboxes are disabled", (): void => {
+    document.body.innerHTML = `
+    <form data-controller="checkbox-select-all" data-checkbox-select-all-ignore-disabled-value="true">
+      <input id="all-disabled" type="checkbox" data-checkbox-select-all-target="checkboxAll" />
+      <input type="checkbox" data-checkbox-select-all-target="checkbox" checked="checked" disabled="disabled" />
+    </form>
+  `
+
+    const toggleCheckbox: HTMLInputElement = document.querySelector("#all-disabled")
+
+    expect(toggleCheckbox.checked).toBe(false)
+    expect(toggleCheckbox.indeterminate).toBe(false)
+  })
+})
+
 describe("when disabled indeterminate state", () => {
   beforeEach((): void => {
     document.body.innerHTML = `

--- a/components/checkbox-select-all/src/index.ts
+++ b/components/checkbox-select-all/src/index.ts
@@ -5,11 +5,16 @@ export default class CheckboxSelectAll extends Controller {
   declare readonly checkboxTargets: HTMLInputElement[]
   declare readonly checkboxAllTarget: HTMLInputElement
   declare readonly disableIndeterminateValue: boolean
+  declare readonly ignoreDisabledValue: boolean
 
   static targets = ["checkboxAll", "checkbox"]
 
   static values = {
     disableIndeterminate: {
+      type: Boolean,
+      default: false,
+    },
+    ignoreDisabled: {
       type: Boolean,
       default: false,
     },
@@ -49,10 +54,17 @@ export default class CheckboxSelectAll extends Controller {
 
     const { checked } = e.target as HTMLInputElement
 
-    this.checkboxTargets.forEach((checkbox) => {
+    // A disabled checkbox cannot be changed by the user and is not submitted with
+    // the form, so the checkboxAll target must never change it either.
+    this.enabled.forEach((checkbox) => {
       checkbox.checked = checked
       this.triggerInputEvent(checkbox)
     })
+
+    // The checkbox targets do not emit a change event here, so the state of the
+    // checkboxAll target must be computed again. It can stay indeterminate when a
+    // disabled checkbox keeps a different state.
+    this.refresh()
   }
 
   refresh(): void {
@@ -60,13 +72,20 @@ export default class CheckboxSelectAll extends Controller {
     // in the DOM, e.g. when it lives in a conditionally rendered header row.
     if (!this.hasCheckboxAllTarget) return
 
-    const checkboxesCount = this.checkboxTargets.length
-    const checkboxesCheckedCount = this.checked.length
+    // The indeterminate state counts the disabled checkboxes, unless the controller
+    // is told to ignore them. The checked state always counts only the checkboxes
+    // the checkboxAll target can change, so a click always toggles the enabled ones.
+    const checkboxes = this.ignoreDisabledValue ? this.enabled : this.checkboxTargets
+    const checkboxesCount = checkboxes.length
+    const checkboxesCheckedCount = checkboxes.filter((checkbox) => checkbox.checked).length
+
+    const enabledCount = this.enabled.length
+    const enabledCheckedCount = this.enabled.filter((checkbox) => checkbox.checked).length
 
     if (this.disableIndeterminateValue) {
-      this.checkboxAllTarget.checked = checkboxesCheckedCount === checkboxesCount
+      this.checkboxAllTarget.checked = enabledCount > 0 && enabledCheckedCount === enabledCount
     } else {
-      this.checkboxAllTarget.checked = checkboxesCheckedCount > 0
+      this.checkboxAllTarget.checked = enabledCheckedCount > 0
       this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
     }
   }
@@ -83,5 +102,13 @@ export default class CheckboxSelectAll extends Controller {
 
   get unchecked(): HTMLInputElement[] {
     return this.checkboxTargets.filter((checkbox) => !checkbox.checked)
+  }
+
+  get enabled(): HTMLInputElement[] {
+    return this.checkboxTargets.filter((checkbox) => !checkbox.disabled)
+  }
+
+  get disabled(): HTMLInputElement[] {
+    return this.checkboxTargets.filter((checkbox) => checkbox.disabled)
   }
 }

--- a/docs/components/content/Demo/CheckboxSelectAll.vue
+++ b/docs/components/content/Demo/CheckboxSelectAll.vue
@@ -17,6 +17,13 @@
                 <span class="ml-2">Team {{ index + 1 }}</span>
               </label>
             </td>
+
+            <td class="block">
+              <label>
+                <input type="checkbox" data-checkbox-select-all-target="checkbox" disabled />
+                <span class="ml-2 opacity-50">Team 4 (disabled)</span>
+              </label>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/docs/content/docs/stimulus-checkbox-select-all.md
+++ b/docs/content/docs/stimulus-checkbox-select-all.md
@@ -139,9 +139,33 @@ end
 
 ## Configuration
 
-| Attribute                                              | Default | Description                      | Optional |
-| ------------------------------------------------------ | ------- | -------------------------------- | -------- |
-| `data-checkbox-select-all-disable-indeterminate-value` | `false` | Disable the indeterminate state. | ✅       |
+| Attribute                                              | Default | Description                                                | Optional |
+| ------------------------------------------------------ | ------- | ---------------------------------------------------------- | -------- |
+| `data-checkbox-select-all-disable-indeterminate-value` | `false` | Disable the indeterminate state.                           | ✅       |
+| `data-checkbox-select-all-ignore-disabled-value`       | `false` | Ignore the disabled checkboxes in the indeterminate state. | ✅       |
+
+### Disabled checkboxes
+
+The `checkboxAll` target never changes a disabled checkbox, because the user cannot change it and the browser does not
+submit it.
+
+By default, the disabled checkboxes are still counted in the indeterminate state. If one disabled checkbox stays
+unchecked, the `checkboxAll` target stays indeterminate after a "Select All" click:
+
+```html
+<form data-controller="checkbox-select-all">
+  <input type="checkbox" data-checkbox-select-all-target="checkboxAll" />
+
+  <input type="checkbox" data-checkbox-select-all-target="checkbox" />
+  <input type="checkbox" data-checkbox-select-all-target="checkbox" disabled />
+</form>
+```
+
+Set `data-checkbox-select-all-ignore-disabled-value="true"` to count only the checkboxes that the `checkboxAll` target
+can change. The indeterminate state then disappears when all the enabled checkboxes are checked.
+
+This value has no effect when `data-checkbox-select-all-disable-indeterminate-value` is `true`, because there is no
+indeterminate state to compute.
 
 ## Extending Controller
 
@@ -161,6 +185,12 @@ export default class extends CheckboxSelectAll {
 
     // Get all unchecked checkboxes
     this.unchecked
+
+    // Get all enabled checkboxes
+    this.enabled
+
+    // Get all disabled checkboxes
+    this.disabled
   }
 }
 ```


### PR DESCRIPTION
Closes #110. Ports https://github.com/stimulus-components/stimulus-checkbox-select-all/pull/10.

## The fix

`toggle()` wrote `checked` on every checkbox target, including the disabled ones. A user cannot change a disabled checkbox and the browser does not submit it, so the `checkboxAll` target must not change it either. It now toggles only the enabled checkbox targets.

## The option

The [review of the original PR](https://github.com/stimulus-components/stimulus-checkbox-select-all/pull/10#issuecomment-773136461) left one question open: what the `checkboxAll` target must show when a disabled checkbox keeps a different state. As [suggested in the issue](https://github.com/stimulus-components/stimulus-components/issues/110#issuecomment-2532622328), it is now an option, like `disableIndeterminate`:

- by default, the disabled checkboxes still count, so the `checkboxAll` target stays indeterminate after a "Select All" click when one disabled checkbox is unchecked;
- with `data-checkbox-select-all-ignore-disabled-value="true"`, only the checkboxes that the `checkboxAll` target can change are counted, and the indeterminate state disappears when all the enabled checkboxes are checked.

## Two related changes

These are necessary to make the option work, and they are the parts that deserve a look:

- **`toggle()` now calls `refresh()`.** The checkbox targets emit no `change` event when the controller writes their `checked` property, so the state of the `checkboxAll` target was never computed again after a click. Without disabled checkboxes this changes nothing, because the recomputed state matches the state the browser already applied.
- **The `checked` property of the `checkboxAll` target now counts only the enabled checkbox targets**, so a click always toggles them. Counting the disabled ones there made the control show a selection it could not clear: with all the enabled checkboxes unchecked and one disabled checkbox checked, every click was read as "deselect all", and the enabled checkboxes could never be checked again. The `indeterminate` property still counts the disabled checkboxes, unless `ignoreDisabled` is set.

This second change also affects `disableIndeterminate` mode on a form that has disabled checkboxes: before, one disabled unchecked checkbox kept the control unchecked for ever; now the control shows checked when all the enabled ones are checked. Tell me if you prefer to keep the old count there.

## Also in this PR

- `enabled` and `disabled` getters, next to `checked` and `unchecked`
- 5 new specs
- a `Disabled checkboxes` section and a new row in the configuration table of the docs
- a disabled checkbox in the docs demo, and two new sections in the local `index.html` playground
- a `minor` changeset

Co-Authored-By: Claude Code <noreply@anthropic.com>
