### PR TITLE
feat(reveal): keep the aria-expanded state of the trigger in sync

### DIFF
--- a/.changeset/reveal-aria-expanded.md
+++ b/.changeset/reveal-aria-expanded.md
@@ -1,0 +1,11 @@
+---
+"@stimulus-components/reveal": minor
+---
+
+Keep the `aria-expanded` attribute of the trigger in sync with the state of the items.
+
+`toggle`, `show` and `hide` now read the event and write `aria-expanded` on the element the action is attached to: `toggle` flips it, `show` sets it to `true`, `hide` sets it to `false`. A screen reader could not tell whether the items were shown or hidden before. Closes #105, and ports stimulus-components/stimulus-reveal-controller#11.
+
+The attribute is opt-in, which is the difference with that pull request: the controller only writes it when the trigger already declares it, so it never adds `aria-expanded` to an element that is not a control for the items. Existing markup is unchanged until an `aria-expanded` attribute is added to the trigger.
+
+The three methods take an optional event parameter, so calling them without one, from a subclass or from another controller, still works.

--- a/components/reveal-controller/index.html
+++ b/components/reveal-controller/index.html
@@ -21,41 +21,41 @@
       <section class="mt-16">
         <div data-controller="reveal">
           <button
-            id="toggle-button"
             data-action="click->reveal#toggle"
             type="button"
+            aria-expanded="false"
             class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow"
           >
             Toggle me!
           </button>
 
-          <p id="toggle-target" data-reveal-target="item" class="hidden mt-4">Hey 👋</p>
+          <p data-reveal-target="item" class="hidden mt-4">Hey 👋</p>
         </div>
 
         <div data-controller="reveal" class="mt-4">
           <button
-            id="toggle-button"
             data-action="click->reveal#hide"
             type="button"
+            aria-expanded="true"
             class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow"
           >
             Hide me!
           </button>
 
-          <p id="toggle-target" data-reveal-target="item" class="mt-4">Hey 🙈</p>
+          <p data-reveal-target="item" class="mt-4">Hey 🙈</p>
         </div>
 
         <div data-controller="reveal" class="mt-4">
           <button
-            id="toggle-button"
             data-action="click->reveal#show"
             type="button"
+            aria-expanded="false"
             class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow"
           >
             Show me!
           </button>
 
-          <p id="toggle-target" data-reveal-target="item" class="hidden mt-4">Hi 🐵</p>
+          <p data-reveal-target="item" class="hidden mt-4">Hi 🐵</p>
         </div>
       </section>
     </div>

--- a/components/reveal-controller/spec/index.test.ts
+++ b/components/reveal-controller/spec/index.test.ts
@@ -22,7 +22,7 @@ beforeEach((): void => {
 
   document.body.innerHTML = `
     <div data-controller="reveal">
-      <button data-action="click->reveal#toggle" type="button">Toggle me!</button>
+      <button data-action="click->reveal#toggle" type="button" aria-expanded="false">Toggle me!</button>
       <p data-reveal-target="item" class="hidden">Hey 👋</p>
     </div>
   `
@@ -38,5 +38,83 @@ describe("#toggle", () => {
     expect(hidden.className).not.toContain("hidden")
     button.click()
     expect(hidden.className).toContain("hidden")
+  })
+
+  it("should keep the aria-expanded attribute in sync", () => {
+    const button: HTMLButtonElement = document.querySelector("button")
+
+    expect(button.getAttribute("aria-expanded")).toEqual("false")
+    button.click()
+    expect(button.getAttribute("aria-expanded")).toEqual("true")
+    button.click()
+    expect(button.getAttribute("aria-expanded")).toEqual("false")
+  })
+
+  describe("without an aria-expanded attribute", () => {
+    beforeEach((): void => {
+      document.body.innerHTML = `
+        <div data-controller="reveal">
+          <button data-action="click->reveal#toggle" type="button">Toggle me!</button>
+          <p data-reveal-target="item" class="hidden">Hey 👋</p>
+        </div>
+      `
+    })
+
+    it("should not add the attribute to the trigger", () => {
+      const button: HTMLButtonElement = document.querySelector("button")
+      const hidden: HTMLElement = document.querySelector("p")
+
+      button.click()
+
+      expect(button.hasAttribute("aria-expanded")).toBe(false)
+      expect(hidden.className).not.toContain("hidden")
+    })
+  })
+})
+
+describe("#show", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div data-controller="reveal">
+        <button data-action="click->reveal#show" type="button" aria-expanded="false">Show me!</button>
+        <p data-reveal-target="item" class="hidden">Hey 👋</p>
+      </div>
+    `
+  })
+
+  it("should reveal the target and set aria-expanded to true", () => {
+    const button: HTMLButtonElement = document.querySelector("button")
+    const hidden: HTMLElement = document.querySelector("p")
+
+    button.click()
+
+    expect(hidden.className).not.toContain("hidden")
+    expect(button.getAttribute("aria-expanded")).toEqual("true")
+
+    button.click()
+
+    expect(hidden.className).not.toContain("hidden")
+    expect(button.getAttribute("aria-expanded")).toEqual("true")
+  })
+})
+
+describe("#hide", () => {
+  beforeEach((): void => {
+    document.body.innerHTML = `
+      <div data-controller="reveal">
+        <button data-action="click->reveal#hide" type="button" aria-expanded="true">Hide me!</button>
+        <p data-reveal-target="item">Hey 👋</p>
+      </div>
+    `
+  })
+
+  it("should hide the target and set aria-expanded to false", () => {
+    const button: HTMLButtonElement = document.querySelector("button")
+    const hidden: HTMLElement = document.querySelector("p")
+
+    button.click()
+
+    expect(hidden.className).toContain("hidden")
+    expect(button.getAttribute("aria-expanded")).toEqual("false")
   })
 })

--- a/components/reveal-controller/src/index.ts
+++ b/components/reveal-controller/src/index.ts
@@ -13,21 +13,41 @@ export default class Reveal extends Controller {
     this.class = this.hasHiddenClass ? this.hiddenClass : "hidden"
   }
 
-  toggle(): void {
+  toggle(event?: Event): void {
     this.itemTargets.forEach((item) => {
       item.classList.toggle(this.class)
     })
+
+    const trigger = this.triggerFor(event)
+
+    if (trigger) {
+      trigger.setAttribute("aria-expanded", String(trigger.getAttribute("aria-expanded") !== "true"))
+    }
   }
 
-  show(): void {
+  show(event?: Event): void {
     this.itemTargets.forEach((item) => {
       item.classList.remove(this.class)
     })
+
+    this.triggerFor(event)?.setAttribute("aria-expanded", "true")
   }
 
-  hide(): void {
+  hide(event?: Event): void {
     this.itemTargets.forEach((item) => {
       item.classList.add(this.class)
     })
+
+    this.triggerFor(event)?.setAttribute("aria-expanded", "false")
+  }
+
+  // The element the action is attached to, but only when it declares an `aria-expanded` attribute.
+  // The attribute stays opt-in: the controller keeps it in sync, it never adds it to a trigger that does not have it.
+  private triggerFor(event?: Event): Element | null {
+    const trigger = event?.currentTarget
+
+    if (!(trigger instanceof Element) || !trigger.hasAttribute("aria-expanded")) return null
+
+    return trigger
   }
 }

--- a/docs/components/content/Demo/Reveal.vue
+++ b/docs/components/content/Demo/Reveal.vue
@@ -2,41 +2,41 @@
   <Block title="Reveal Controller">
     <div data-controller="reveal">
       <button
-        id="toggle-button"
         data-action="reveal#toggle"
         type="button"
+        aria-expanded="false"
         class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow"
       >
         Toggle me!
       </button>
 
-      <p id="toggle-target" data-reveal-target="item" class="hidden mt-4">Hey 👋</p>
+      <p data-reveal-target="item" class="hidden mt-4">Hey 👋</p>
     </div>
 
     <div data-controller="reveal" class="mt-4">
       <button
-        id="toggle-button"
         data-action="reveal#hide"
         type="button"
+        aria-expanded="true"
         class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow"
       >
         Hide me!
       </button>
 
-      <p id="toggle-target" data-reveal-target="item" class="mt-4">Hey 🙈</p>
+      <p data-reveal-target="item" class="mt-4">Hey 🙈</p>
     </div>
 
     <div data-controller="reveal" class="mt-4">
       <button
-        id="toggle-button"
         data-action="reveal#show"
         type="button"
+        aria-expanded="false"
         class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow"
       >
         Show me!
       </button>
 
-      <p id="toggle-target" data-reveal-target="item" class="hidden mt-4">Hi 🐵</p>
+      <p data-reveal-target="item" class="hidden mt-4">Hi 🐵</p>
     </div>
   </Block>
 </template>

--- a/docs/content/docs/stimulus-reveal-controller.md
+++ b/docs/content/docs/stimulus-reveal-controller.md
@@ -21,7 +21,7 @@ packagePath: "@stimulus-components/reveal"
 
 ```html
 <div data-controller="reveal" data-reveal-hidden-class="d-none">
-  <button data-action="reveal#toggle" type="button" class="btn">Toggle me!</button>
+  <button data-action="reveal#toggle" type="button" class="btn" aria-expanded="false">Toggle me!</button>
 
   <p data-reveal-target="item" class="d-none mt-4">Hey 👋</p>
   <p data-reveal-target="item" class="d-none mt-4">You can have multiple items</p>
@@ -36,7 +36,7 @@ packagePath: "@stimulus-components/reveal"
 
 ```html
 <div data-controller="reveal">
-  <button data-action="reveal#show" type="button" class="btn">Show me!</button>
+  <button data-action="reveal#show" type="button" class="btn" aria-expanded="false">Show me!</button>
 
   <p data-reveal-target="item" class="hidden mt-4">Hey 👋</p>
 </div>
@@ -50,13 +50,19 @@ packagePath: "@stimulus-components/reveal"
 
 ```html
 <div data-controller="reveal">
-  <button data-action="reveal#hide" type="button" class="btn">Hide me!</button>
+  <button data-action="reveal#hide" type="button" class="btn" aria-expanded="true">Hide me!</button>
 
   <p data-reveal-target="item" class="mt-4">Hey 👋</p>
 </div>
 ```
 
 ::
+
+### Accessibility
+
+When the element the action is attached to already has an `aria-expanded` attribute, the controller keeps it in sync: `toggle` flips it, `show` sets it to `true` and `hide` sets it to `false`. Give it the value that matches the initial state of the items, `aria-expanded="false"` when they start hidden.
+
+The attribute is opt-in. The controller never adds it to an element that does not declare it, because `aria-expanded` is only valid on a control that shows and hides content.
 
 ## Configuration
 


### PR DESCRIPTION
Closes #105, and ports the archived stimulus-components/stimulus-reveal-controller#11.

A screen reader could not tell whether the items of a `reveal` controller were shown or hidden, because nothing wrote the state back to the trigger.

`toggle`, `show` and `hide` now write `aria-expanded` on the element the action is attached to:

- `toggle` flips it,
- `show` sets it to `true`,
- `hide` sets it to `false`.

## Opt-in

This is the one difference with #11, which set the attribute unconditionally.

The controller only writes `aria-expanded` when the trigger already declares it. `aria-expanded` is only valid on a control that shows and hides content, and a `reveal` action can be put on any element, so writing it unconditionally can add incorrect ARIA to markup that did not ask for it. Existing markup is unchanged until an `aria-expanded` attribute is added to the trigger.

```html
<div data-controller="reveal">
  <button data-action="reveal#toggle" type="button" aria-expanded="false">Toggle me!</button>

  <p data-reveal-target="item" class="hidden mt-4">Hey 👋</p>
</div>
```

The event parameter is optional, so calling the methods from a subclass or from another controller still works.

## Changes

- `components/reveal-controller/src/index.ts`: the three methods take an optional event, plus a private `triggerFor` helper that returns the trigger only when it is an `Element` that declares `aria-expanded`.
- `components/reveal-controller/spec/index.test.ts`: 4 new tests, one per method and one for a trigger without the attribute.
- `docs/content/docs/stimulus-reveal-controller.md`: `aria-expanded` in the three examples, and an "Accessibility" section for the opt-in rule.
- `docs/components/content/Demo/Reveal.vue` and `components/reveal-controller/index.html`: `aria-expanded` added, and the duplicate `id="toggle-button"` / `id="toggle-target"` attributes removed, as in #11.
- A `minor` changeset.

Co-Authored-By: Claude Code <noreply@anthropic.com>
