### PR TITLE
feat(lightbox)!: replace lightGallery with PhotoSwipe

### DIFF
--- a/.changeset/lightbox-photoswipe.md
+++ b/.changeset/lightbox-photoswipe.md
@@ -1,0 +1,16 @@
+---
+"@stimulus-components/lightbox": major
+---
+
+Replace `lightgallery` with [PhotoSwipe](https://photoswipe.com/).
+
+lightGallery is dual-licensed: it is free for open source projects, but "if you are using the library for business, commercial sites, projects, and applications, the Commercial license is the appropriate license". Without a key it logs `lightGallery: 0000-0000-000-0000 license key is not valid for production use` in the console, and the key could not be set through this controller anyway. PhotoSwipe is MIT, has no dependencies, and needs no key. This closes [#107](https://github.com/stimulus-components/stimulus-components/issues/107).
+
+This is a **major** bump because the underlying library, the markup, and the options all change:
+
+- Import `photoswipe/style.css` instead of `lightgallery/css/lightgallery.css`.
+- Add `data-pswp-width` and `data-pswp-height` to every link of the gallery. PhotoSwipe needs the size of the full resolution image to open it without a layout shift.
+- Rewrite `data-lightbox-options-value` with the [PhotoSwipe options](https://photoswipe.com/options/). No lightGallery option carries over as is.
+- The instance is exposed as `this.photoSwipe` instead of `this.lightGallery`.
+
+The controller always sets `gallery` to the controller element. `children` defaults to `"a"` and `pswpModule` to the PhotoSwipe core module; both can be overridden through `defaultOptions` or `data-lightbox-options-value`. Overriding `pswpModule` with `() => import("photoswipe")` loads the core on the first click instead of upfront.

--- a/components/lightbox/index.html
+++ b/components/lightbox/index.html
@@ -10,7 +10,7 @@
       import "../app.css"
       import { Application } from "@hotwired/stimulus"
       import Lightbox from "./src/index"
-      import "lightgallery/css/lightgallery.css"
+      import "photoswipe/style.css"
 
       const application = Application.start()
       application.register("lightbox", Lightbox)
@@ -22,28 +22,34 @@
       <section class="mt-16">
         <div data-controller="lightbox" class="grid gap-4 md:grid-cols-3">
           <a
-            href="https://images.unsplash.com/photo-1604042292937-4b2b4781c821?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2081&q=80"
+            href="https://images.unsplash.com/photo-1604042292937-4b2b4781c821?ixlib=rb-1.2.1&auto=format&fit=crop&w=1600&h=1067"
+            data-pswp-width="1600"
+            data-pswp-height="1067"
           >
             <img
-              src="https://images.unsplash.com/photo-1604042292937-4b2b4781c821?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2081&q=80"
+              src="https://images.unsplash.com/photo-1604042292937-4b2b4781c821?ixlib=rb-1.2.1&auto=format&fit=crop&w=600&h=400"
               alt=""
             />
           </a>
 
           <a
-            href="https://images.unsplash.com/photo-1603878662588-5908ad857cd4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1615&q=80"
+            href="https://images.unsplash.com/photo-1603878662588-5908ad857cd4?ixlib=rb-1.2.1&auto=format&fit=crop&w=1600&h=1067"
+            data-pswp-width="1600"
+            data-pswp-height="1067"
           >
             <img
-              src="https://images.unsplash.com/photo-1603878662588-5908ad857cd4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1615&q=80"
+              src="https://images.unsplash.com/photo-1603878662588-5908ad857cd4?ixlib=rb-1.2.1&auto=format&fit=crop&w=600&h=400"
               alt=""
             />
           </a>
 
           <a
-            href="https://images.unsplash.com/photo-1474044159687-1ee9f3a51722?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+            href="https://images.unsplash.com/photo-1474044159687-1ee9f3a51722?ixlib=rb-1.2.1&auto=format&fit=crop&w=1600&h=1067"
+            data-pswp-width="1600"
+            data-pswp-height="1067"
           >
             <img
-              src="https://images.unsplash.com/photo-1474044159687-1ee9f3a51722?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+              src="https://images.unsplash.com/photo-1474044159687-1ee9f3a51722?ixlib=rb-1.2.1&auto=format&fit=crop&w=600&h=400"
               alt=""
             />
           </a>

--- a/components/lightbox/package.json
+++ b/components/lightbox/package.json
@@ -7,7 +7,7 @@
     "stimulusjs",
     "stimulus controller",
     "lightbox",
-    "lightgallery"
+    "photoswipe"
   ],
   "repository": "git@github.com:stimulus-components/stimulus-components.git",
   "bugs": {
@@ -40,7 +40,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "lightgallery": "^2.7.2"
+    "photoswipe": "^5.4.4"
   },
   "peerDependencies": {
     "@hotwired/stimulus": "^3"

--- a/components/lightbox/spec/index.test.ts
+++ b/components/lightbox/spec/index.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import PhotoSwipe from "photoswipe"
+import Lightbox from "../src/index"
+
+let application: Application
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("lightbox", Lightbox)
+}
+
+// Stimulus connects controllers from a MutationObserver callback, so markup
+// assigned inside a test body is not live until the microtask queue drains.
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+const gallery = (options = ""): string => `
+  <div id="gallery" data-controller="lightbox" ${options}>
+    <a href="img1.jpg" data-pswp-width="1600" data-pswp-height="1067"><img src="thumb1.jpg" alt="" /></a>
+    <a href="img2.jpg" data-pswp-width="1600" data-pswp-height="1067"><img src="thumb2.jpg" alt="" /></a>
+  </div>
+`
+
+const controllerFor = (element: Element): Lightbox =>
+  application.getControllerForElementAndIdentifier(element, "lightbox") as Lightbox
+
+afterEach((): void => {
+  application.stop()
+  document.body.innerHTML = ""
+})
+
+beforeEach((): void => {
+  startStimulus()
+})
+
+describe("Lightbox", (): void => {
+  it("builds a PhotoSwipe lightbox bound to the controller element", async (): Promise<void> => {
+    document.body.innerHTML = gallery()
+    await flush()
+
+    const element = document.getElementById("gallery")!
+    const { photoSwipe } = controllerFor(element)
+
+    expect(photoSwipe.options.gallery).toBe(element)
+    expect(photoSwipe.options.children).toBe("a")
+    expect(photoSwipe.options.pswpModule).toBe(PhotoSwipe)
+  })
+
+  it("merges the options value over the defaults", async (): Promise<void> => {
+    document.body.innerHTML = gallery(`data-lightbox-options-value='{"children": "a.item", "loop": false}'`)
+    await flush()
+
+    const { photoSwipe } = controllerFor(document.getElementById("gallery")!)
+
+    expect(photoSwipe.options.children).toBe("a.item")
+    expect(photoSwipe.options.loop).toBe(false)
+  })
+
+  it("keeps the controller element as the gallery even when the options value sets one", async (): Promise<void> => {
+    document.body.innerHTML = gallery(`data-lightbox-options-value='{"gallery": "#somewhere-else"}'`)
+    await flush()
+
+    const element = document.getElementById("gallery")!
+
+    expect(controllerFor(element).photoSwipe.options.gallery).toBe(element)
+  })
+
+  it("destroys the lightbox on disconnect", async (): Promise<void> => {
+    document.body.innerHTML = gallery()
+    await flush()
+
+    const element = document.getElementById("gallery")!
+    const { photoSwipe } = controllerFor(element)
+    const removeEventListener = vi.spyOn(element, "removeEventListener")
+
+    element.remove()
+    await flush()
+
+    // destroy() drops the click listener it bound on the gallery element.
+    expect(removeEventListener).toHaveBeenCalledWith("click", photoSwipe.onThumbnailsClick, false)
+  })
+})

--- a/components/lightbox/src/index.ts
+++ b/components/lightbox/src/index.ts
@@ -1,28 +1,33 @@
 import { Controller } from "@hotwired/stimulus"
-import lightGallery from "lightgallery"
-import type { LightGallerySettings } from "lightgallery/lg-settings"
-import type { LightGallery } from "lightgallery/lightgallery"
+import PhotoSwipe from "photoswipe"
+import type { PhotoSwipeOptions } from "photoswipe"
+import PhotoSwipeLightbox from "photoswipe/lightbox"
 
 export default class Lightbox extends Controller<HTMLElement> {
-  declare optionsValue: LightGallerySettings
-  declare lightGallery: LightGallery
+  declare optionsValue: PhotoSwipeOptions
+  declare photoSwipe: PhotoSwipeLightbox
 
   static values = {
     options: Object,
   }
 
   connect(): void {
-    this.lightGallery = lightGallery(this.element, {
+    this.photoSwipe = new PhotoSwipeLightbox({
+      children: "a",
+      pswpModule: PhotoSwipe,
       ...this.defaultOptions,
       ...this.optionsValue,
+      gallery: this.element,
     })
+
+    this.photoSwipe.init()
   }
 
   disconnect(): void {
-    this.lightGallery.destroy()
+    this.photoSwipe.destroy()
   }
 
-  get defaultOptions(): LightGallerySettings {
+  get defaultOptions(): PhotoSwipeOptions {
     return {}
   }
 }

--- a/components/lightbox/vite.config.mts
+++ b/components/lightbox/vite.config.mts
@@ -12,10 +12,11 @@ export default defineConfig({
       fileName: "stimulus-lightbox",
     },
     rollupOptions: {
-      external: ["lightgallery", "@hotwired/stimulus"],
+      external: ["photoswipe", "photoswipe/lightbox", "@hotwired/stimulus"],
       output: {
         globals: {
-          lightgallery: "lightgallery",
+          photoswipe: "PhotoSwipe",
+          "photoswipe/lightbox": "PhotoSwipeLightbox",
           "@hotwired/stimulus": "Stimulus",
         },
       },

--- a/docs/components/content/Demo/Lightbox.vue
+++ b/docs/components/content/Demo/Lightbox.vue
@@ -2,28 +2,34 @@
   <Block title="Lightbox">
     <div data-controller="lightbox" class="grid gap-4 md:grid-cols-3">
       <a
-        href="https://images.unsplash.com/photo-1604042292937-4b2b4781c821?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2081&q=80"
+        href="https://images.unsplash.com/photo-1604042292937-4b2b4781c821?ixlib=rb-1.2.1&auto=format&fit=crop&w=1600&h=1067"
+        data-pswp-width="1600"
+        data-pswp-height="1067"
       >
         <img
-          src="https://images.unsplash.com/photo-1604042292937-4b2b4781c821?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2081&q=80"
+          src="https://images.unsplash.com/photo-1604042292937-4b2b4781c821?ixlib=rb-1.2.1&auto=format&fit=crop&w=600&h=400"
           alt=""
         />
       </a>
 
       <a
-        href="https://images.unsplash.com/photo-1603878662588-5908ad857cd4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1615&q=80"
+        href="https://images.unsplash.com/photo-1603878662588-5908ad857cd4?ixlib=rb-1.2.1&auto=format&fit=crop&w=1600&h=1067"
+        data-pswp-width="1600"
+        data-pswp-height="1067"
       >
         <img
-          src="https://images.unsplash.com/photo-1603878662588-5908ad857cd4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1615&q=80"
+          src="https://images.unsplash.com/photo-1603878662588-5908ad857cd4?ixlib=rb-1.2.1&auto=format&fit=crop&w=600&h=400"
           alt=""
         />
       </a>
 
       <a
-        href="https://images.unsplash.com/photo-1474044159687-1ee9f3a51722?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        href="https://images.unsplash.com/photo-1474044159687-1ee9f3a51722?ixlib=rb-1.2.1&auto=format&fit=crop&w=1600&h=1067"
+        data-pswp-width="1600"
+        data-pswp-height="1067"
       >
         <img
-          src="https://images.unsplash.com/photo-1474044159687-1ee9f3a51722?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+          src="https://images.unsplash.com/photo-1474044159687-1ee9f3a51722?ixlib=rb-1.2.1&auto=format&fit=crop&w=600&h=400"
           alt=""
         />
       </a>
@@ -33,5 +39,5 @@
 
 <script setup>
 import Block from "@/components/UI/Block.vue"
-import "lightgallery/css/lightgallery.css"
+import "photoswipe/style.css"
 </script>

--- a/docs/content/docs/stimulus-lightbox.md
+++ b/docs/content/docs/stimulus-lightbox.md
@@ -10,7 +10,7 @@ packagePath: "@stimulus-components/lightbox"
 :installation-block{:package="package" :packagePath="packagePath"}
 
 ::alert
-This component is based on the [lightgalleryjs](https://www.lightgalleryjs.com/){target="\_blank" .underline .hover:no-underline}.
+This component is based on [PhotoSwipe](https://photoswipe.com/){target="\_blank" .underline .hover:no-underline}.
 ::
 
 ## Example
@@ -19,12 +19,12 @@ This component is based on the [lightgalleryjs](https://www.lightgalleryjs.com/)
 
 ## Usage
 
-Before starting, your must import the `lightgallery.css` in your `js` or in your `sass`:
+Before starting, you must import the PhotoSwipe stylesheet in your `js` or in your `sass`:
 
 ::code-block{tabName="app/javascript/index.js"}
 
 ```js
-import "lightgallery/css/lightgallery.css"
+import "photoswipe/style.css"
 ```
 
 ::
@@ -33,25 +33,27 @@ Or in your sass:
 ::code-block{tabName="app/javascript/stylesheets/application.scss"}
 
 ```scss
-@import "~lightgallery/scss/lightgallery";
+@import "photoswipe/style.css";
 ```
 
 ::
+
+Every link inside the gallery must declare the size of the full resolution image with `data-pswp-width` and `data-pswp-height`. PhotoSwipe needs both to open the image at the right size without a layout shift.
 
 ::code-block{tabName="app/views/index.html"}
 
 ```html
 <div data-controller="lightbox">
-  <a href="img/img1.jpg">
-    <img src="img/img1.jpg" alt="" />
+  <a href="img/img1.jpg" data-pswp-width="1600" data-pswp-height="1067">
+    <img src="img/thumb1.jpg" alt="" />
   </a>
 
-  <a href="img/img2.jpg">
-    <img src="img/img2.jpg" alt="" />
+  <a href="img/img2.jpg" data-pswp-width="1600" data-pswp-height="1067">
+    <img src="img/thumb2.jpg" alt="" />
   </a>
 
-  <a href="img/img3.jpg">
-    <img src="img/img3.jpg" alt="" />
+  <a href="img/img3.jpg" data-pswp-width="1600" data-pswp-height="1067">
+    <img src="img/thumb3.jpg" alt="" />
   </a>
 </div>
 ```
@@ -63,17 +65,13 @@ With options:
 ::code-block{tabName="app/views/index.html"}
 
 ```html
-<div data-controller="lightbox" data-lightbox-options-value='{"index": 2}'>
-  <a href="img/img1.jpg">
-    <img src="img/img1.jpg" alt="" />
+<div data-controller="lightbox" data-lightbox-options-value='{"bgOpacity": 0.9, "loop": false}'>
+  <a href="img/img1.jpg" data-pswp-width="1600" data-pswp-height="1067">
+    <img src="img/thumb1.jpg" alt="" />
   </a>
 
-  <a href="img/img2.jpg">
-    <img src="img/img2.jpg" alt="" />
-  </a>
-
-  <a href="img/img3.jpg">
-    <img src="img/img3.jpg" alt="" />
+  <a href="img/img2.jpg" data-pswp-width="1600" data-pswp-height="1067">
+    <img src="img/thumb2.jpg" alt="" />
   </a>
 </div>
 ```
@@ -82,9 +80,23 @@ With options:
 
 ## Configuration
 
-| Attribute                     | Default | Description                                 | Optional |
-| ----------------------------- | ------- | ------------------------------------------- | -------- |
-| `data-lightbox-options-value` | `{}`    | Options for lightgallery.js as JSON string. | ✅       |
+| Attribute                     | Default | Description                                                                                                                | Optional |
+| ----------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `data-lightbox-options-value` | `{}`    | [Options for PhotoSwipe](https://photoswipe.com/options/){target="\_blank" .underline .hover:no-underline} as JSON string. | ✅       |
+
+The controller always sets `gallery` to the controller element, so that option is ignored. `children` defaults to `"a"` and `pswpModule` to the PhotoSwipe core module; both can be overridden.
+
+## Migrating from v4
+
+Version 5 replaces [lightGallery](https://www.lightgalleryjs.com/){target="\_blank" .underline .hover:no-underline} with [PhotoSwipe](https://photoswipe.com/){target="\_blank" .underline .hover:no-underline}. lightGallery is dual-licensed and requires a paid license key for commercial use, while PhotoSwipe is MIT. Three things change:
+
+1. Import `photoswipe/style.css` instead of `lightgallery/css/lightgallery.css`.
+2. Add `data-pswp-width` and `data-pswp-height` to every link of the gallery.
+3. Replace the lightGallery options in `data-lightbox-options-value` with their [PhotoSwipe equivalents](https://photoswipe.com/options/){target="\_blank" .underline .hover:no-underline}. The option names are different, and no option carries over as is.
+
+The instance is now exposed as `this.photoSwipe` instead of `this.lightGallery`.
+
+You do not have to install `photoswipe` yourself, it ships as a dependency of the package.
 
 ## Extending Controller
 
@@ -99,8 +111,8 @@ export default class extends Lightbox {
     super.connect()
     console.log("Do what you want here.")
 
-    // Get the lightgallery instance
-    this.lightGallery
+    // Get the PhotoSwipe lightbox instance
+    this.photoSwipe
 
     // Default options for every lightboxes.
     this.defaultOptions
@@ -109,7 +121,8 @@ export default class extends Lightbox {
   // You can set default options in this getter.
   get defaultOptions() {
     return {
-      // Your default options here
+      // Load the PhotoSwipe core on the first click instead of upfront.
+      pswpModule: () => import("photoswipe"),
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,9 @@ importers:
       '@hotwired/stimulus':
         specifier: ^3
         version: 3.2.2
-      lightgallery:
-        specifier: ^2.7.2
-        version: 2.8.3
+      photoswipe:
+        specifier: ^5.4.4
+        version: 5.4.4
 
   components/notification:
     dependencies:
@@ -307,19 +307,19 @@ importers:
         version: 3.2.2
       '@nuxt/content':
         specifier: ^2.13.4
-        version: 2.13.4(ioredis@5.10.0)(magicast@0.3.5)(nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4))(rollup@4.59.0)(vue@3.5.29(typescript@6.0.3))
+        version: 2.13.4(ioredis@5.10.0)(magicast@0.5.2)(nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4))(rollup@4.59.0)(vue@3.5.29(typescript@6.0.3))
       '@nuxtjs/algolia':
         specifier: ^1.11.2
-        version: 1.11.2(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@6.0.3)))(magicast@0.3.5)(rollup@4.59.0)(vue@3.5.29(typescript@6.0.3))
+        version: 1.11.2(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@6.0.3)))(magicast@0.5.2)(rollup@4.59.0)(vue@3.5.29(typescript@6.0.3))
       '@nuxtjs/color-mode':
         specifier: ^3.5.2
-        version: 3.5.2(magicast@0.3.5)(rollup@4.59.0)
+        version: 3.5.2(magicast@0.5.2)(rollup@4.59.0)
       '@nuxtjs/plausible':
         specifier: ^1.2.0
-        version: 1.2.0(magicast@0.3.5)(rollup@4.59.0)
+        version: 1.2.0(magicast@0.5.2)(rollup@4.59.0)
       '@nuxtjs/robots':
         specifier: ^3.0.0
-        version: 3.0.0(magicast@0.3.5)(rollup@4.59.0)
+        version: 3.0.0(magicast@0.5.2)(rollup@4.59.0)
       '@stimulus-components/animated-number':
         specifier: workspace:*
         version: link:../components/animated-number
@@ -412,7 +412,7 @@ importers:
         version: 3.45.1
       nuxt:
         specifier: ^3.19.2
-        version: 3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4)
+        version: 3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4)
       stimulus-glow:
         specifier: workspace:*
         version: link:../components/glow
@@ -4665,10 +4665,6 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lightgallery@2.8.3:
-    resolution: {integrity: sha512-s67Z7KZAhIu/io7qs2yIM+8+hUyDQ1ufRtCQwhFnmHVzRQ8cKlxf53CxS/DpJ0sDGOWHNx5L6Y3PfACQxiH+8A==}
-    engines: {node: '>=6.0.0'}
-
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -5519,6 +5515,10 @@ packages:
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
+  photoswipe@5.4.4:
+    resolution: {integrity: sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA==}
+    engines: {node: '>= 0.12.0'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -8190,11 +8190,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@nuxt/cli@3.33.1(@nuxt/schema@3.19.3)(cac@6.7.14)(magicast@0.3.5)':
+  '@nuxt/cli@3.33.1(@nuxt/schema@3.19.3)(cac@6.7.14)(magicast@0.5.2)':
     dependencies:
       '@bomb.sh/tab': 0.0.12(cac@6.7.14)(citty@0.2.1)
       '@clack/prompts': 1.0.1
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -8228,13 +8228,13 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/content@2.13.4(ioredis@5.10.0)(magicast@0.3.5)(nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4))(rollup@4.59.0)(vue@3.5.29(typescript@6.0.3))':
+  '@nuxt/content@2.13.4(ioredis@5.10.0)(magicast@0.5.2)(nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4))(rollup@4.59.0)(vue@3.5.29(typescript@6.0.3))':
     dependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.59.0)
-      '@nuxtjs/mdc': 0.9.5(magicast@0.3.5)
+      '@nuxt/kit': 3.13.2(magicast@0.5.2)(rollup@4.59.0)
+      '@nuxtjs/mdc': 0.9.5(magicast@0.5.2)
       '@vueuse/core': 11.3.0(vue@3.5.29(typescript@6.0.3))
       '@vueuse/head': 2.0.0(vue@3.5.29(typescript@6.0.3))
-      '@vueuse/nuxt': 11.3.0(magicast@0.3.5)(nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4))(vue@3.5.29(typescript@6.0.3))
+      '@vueuse/nuxt': 11.3.0(magicast@0.5.2)(nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4))(vue@3.5.29(typescript@6.0.3))
       consola: 3.2.3
       defu: 6.1.4
       destr: 2.0.3
@@ -8332,7 +8332,7 @@ snapshots:
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
       vite: 7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.19.3(magicast@0.3.5))(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.19.3(magicast@0.5.2))(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))
       vite-plugin-vue-tracer: 1.2.0(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(vue@3.5.29(typescript@6.0.3))
       which: 5.0.0
       ws: 8.19.0
@@ -8382,10 +8382,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/kit@3.11.2(magicast@0.3.5)(rollup@4.59.0)':
+  '@nuxt/kit@3.11.2(magicast@0.5.2)(rollup@4.59.0)':
     dependencies:
       '@nuxt/schema': 3.11.2(rollup@4.59.0)
-      c12: 1.11.2(magicast@0.3.5)
+      c12: 1.11.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       globby: 14.0.1
@@ -8407,10 +8407,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.59.0)':
+  '@nuxt/kit@3.13.2(magicast@0.5.2)(rollup@4.59.0)':
     dependencies:
       '@nuxt/schema': 3.13.2(rollup@4.59.0)
-      c12: 1.11.2(magicast@0.3.5)
+      c12: 1.11.2(magicast@0.5.2)
       consola: 3.2.3
       defu: 6.1.4
       destr: 2.0.3
@@ -8434,10 +8434,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.59.0)':
+  '@nuxt/kit@3.14.1592(magicast@0.5.2)(rollup@4.59.0)':
     dependencies:
-      '@nuxt/schema': 3.14.1592(magicast@0.3.5)(rollup@4.59.0)
-      c12: 2.0.4(magicast@0.3.5)
+      '@nuxt/schema': 3.14.1592(magicast@0.5.2)(rollup@4.59.0)
+      c12: 2.0.4(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -8489,9 +8489,37 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@3.21.1(magicast@0.3.5)':
+  '@nuxt/kit@3.19.3(magicast@0.5.2)':
     dependencies:
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.6
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      mlly: 1.8.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 3.10.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.3
+      unctx: 2.5.0
+      unimport: 5.7.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/kit@3.21.1(magicast@0.5.2)':
+    dependencies:
+      c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -8550,9 +8578,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.14.1592(magicast@0.3.5)(rollup@4.59.0)':
+  '@nuxt/schema@3.14.1592(magicast@0.5.2)(rollup@4.59.0)':
     dependencies:
-      c12: 2.0.4(magicast@0.3.5)
+      c12: 2.0.4(magicast@0.5.2)
       compatx: 0.1.8
       consola: 3.4.2
       defu: 6.1.4
@@ -8580,9 +8608,9 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.1
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@3.19.3(magicast@0.3.5))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@3.19.3(magicast@0.5.2))':
     dependencies:
-      '@nuxt/kit': 3.19.3(magicast@0.3.5)
+      '@nuxt/kit': 3.19.3(magicast@0.5.2)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
@@ -8591,9 +8619,9 @@ snapshots:
 
   '@nuxt/ui-templates@1.3.4': {}
 
-  '@nuxt/vite-builder@3.19.3(@types/node@24.5.2)(eslint@10.8.1(jiti@2.6.1))(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vue@3.5.29(typescript@6.0.3))(yaml@2.8.4)':
+  '@nuxt/vite-builder@3.19.3(@types/node@24.5.2)(eslint@10.8.1(jiti@2.6.1))(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vue@3.5.29(typescript@6.0.3))(yaml@2.8.4)':
     dependencies:
-      '@nuxt/kit': 3.19.3(magicast@0.3.5)
+      '@nuxt/kit': 3.19.3(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.4(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(vue@3.5.29(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(vue@3.5.29(typescript@6.0.3))
@@ -8653,13 +8681,13 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxtjs/algolia@1.11.2(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@6.0.3)))(magicast@0.3.5)(rollup@4.59.0)(vue@3.5.29(typescript@6.0.3))':
+  '@nuxtjs/algolia@1.11.2(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@6.0.3)))(magicast@0.5.2)(rollup@4.59.0)(vue@3.5.29(typescript@6.0.3))':
     dependencies:
       '@algolia/cache-in-memory': 4.23.3
       '@algolia/recommend': 4.23.3
       '@algolia/requester-fetch': 4.23.3
       '@algolia/requester-node-http': 5.37.0
-      '@nuxt/kit': 3.11.2(magicast@0.3.5)(rollup@4.59.0)
+      '@nuxt/kit': 3.11.2(magicast@0.5.2)(rollup@4.59.0)
       algoliasearch: 4.23.3
       defu: 6.1.4
       exsolve: 1.0.7
@@ -8677,9 +8705,9 @@ snapshots:
       - vue
       - vue-server-renderer
 
-  '@nuxtjs/color-mode@3.5.2(magicast@0.3.5)(rollup@4.59.0)':
+  '@nuxtjs/color-mode@3.5.2(magicast@0.5.2)(rollup@4.59.0)':
     dependencies:
-      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.59.0)
+      '@nuxt/kit': 3.13.2(magicast@0.5.2)(rollup@4.59.0)
       pathe: 1.1.2
       pkg-types: 1.2.1
       semver: 7.6.3
@@ -8688,9 +8716,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxtjs/mdc@0.9.5(magicast@0.3.5)':
+  '@nuxtjs/mdc@0.9.5(magicast@0.5.2)':
     dependencies:
-      '@nuxt/kit': 3.21.1(magicast@0.3.5)
+      '@nuxt/kit': 3.21.1(magicast@0.5.2)
       '@shikijs/transformers': 1.24.2
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -8730,10 +8758,10 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxtjs/plausible@1.2.0(magicast@0.3.5)(rollup@4.59.0)':
+  '@nuxtjs/plausible@1.2.0(magicast@0.5.2)(rollup@4.59.0)':
     dependencies:
       '@barbapapazes/plausible-tracker': 0.5.6
-      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.59.0)
+      '@nuxt/kit': 3.14.1592(magicast@0.5.2)(rollup@4.59.0)
       defu: 6.1.4
       ufo: 1.5.4
     transitivePeerDependencies:
@@ -8741,9 +8769,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxtjs/robots@3.0.0(magicast@0.3.5)(rollup@4.59.0)':
+  '@nuxtjs/robots@3.0.0(magicast@0.5.2)(rollup@4.59.0)':
     dependencies:
-      '@nuxt/kit': 3.11.2(magicast@0.3.5)(rollup@4.59.0)
+      '@nuxt/kit': 3.11.2(magicast@0.5.2)(rollup@4.59.0)
       h3: 1.11.1
     transitivePeerDependencies:
       - magicast
@@ -9883,13 +9911,13 @@ snapshots:
 
   '@vueuse/metadata@11.3.0': {}
 
-  '@vueuse/nuxt@11.3.0(magicast@0.3.5)(nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4))(vue@3.5.29(typescript@6.0.3))':
+  '@vueuse/nuxt@11.3.0(magicast@0.5.2)(nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4))(vue@3.5.29(typescript@6.0.3))':
     dependencies:
-      '@nuxt/kit': 3.21.1(magicast@0.3.5)
+      '@nuxt/kit': 3.21.1(magicast@0.5.2)
       '@vueuse/core': 11.3.0(vue@3.5.29(typescript@6.0.3))
       '@vueuse/metadata': 11.3.0
       local-pkg: 0.5.1
-      nuxt: 3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4)
+      nuxt: 3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4)
       vue-demi: 0.14.10(vue@3.5.29(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -10136,7 +10164,7 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
-  c12@1.11.2(magicast@0.3.5):
+  c12@1.11.2(magicast@0.5.2):
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
@@ -10151,9 +10179,9 @@ snapshots:
       pkg-types: 1.3.1
       rc9: 2.1.2
     optionalDependencies:
-      magicast: 0.3.5
+      magicast: 0.5.2
 
-  c12@2.0.4(magicast@0.3.5):
+  c12@2.0.4(magicast@0.5.2):
     dependencies:
       chokidar: 4.0.3
       confbox: 0.1.8
@@ -10168,7 +10196,7 @@ snapshots:
       pkg-types: 1.3.1
       rc9: 2.1.2
     optionalDependencies:
-      magicast: 0.3.5
+      magicast: 0.5.2
 
   c12@3.3.3(magicast@0.3.5):
     dependencies:
@@ -11742,8 +11770,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightgallery@2.8.3: {}
-
   lightningcss-android-arm64@1.32.0:
     optional: true
 
@@ -12628,18 +12654,18 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4):
+  nuxt@3.19.3(@parcel/watcher@2.4.1)(@types/node@24.5.2)(@vue/compiler-sfc@3.5.29)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@10.8.1(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(yaml@2.8.4):
     dependencies:
-      '@nuxt/cli': 3.33.1(@nuxt/schema@3.19.3)(cac@6.7.14)(magicast@0.3.5)
+      '@nuxt/cli': 3.33.1(@nuxt/schema@3.19.3)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))(vue@3.5.29(typescript@6.0.3))
-      '@nuxt/kit': 3.19.3(magicast@0.3.5)
+      '@nuxt/kit': 3.19.3(magicast@0.5.2)
       '@nuxt/schema': 3.19.3
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@3.19.3(magicast@0.3.5))
-      '@nuxt/vite-builder': 3.19.3(@types/node@24.5.2)(eslint@10.8.1(jiti@2.6.1))(lightningcss@1.33.0)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vue@3.5.29(typescript@6.0.3))(yaml@2.8.4)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@3.19.3(magicast@0.5.2))
+      '@nuxt/vite-builder': 3.19.3(@types/node@24.5.2)(eslint@10.8.1(jiti@2.6.1))(lightningcss@1.33.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.2.1)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(vue@3.5.29(typescript@6.0.3))(yaml@2.8.4)
       '@unhead/vue': 2.1.9(vue@3.5.29(typescript@6.0.3))
       '@vue/shared': 3.5.29
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2
@@ -12998,6 +13024,8 @@ snapshots:
   perfect-debounce@1.0.0: {}
 
   perfect-debounce@2.1.0: {}
+
+  photoswipe@5.4.4: {}
 
   picocolors@1.1.1: {}
 
@@ -14332,7 +14360,7 @@ snapshots:
       optionator: 0.9.4
       typescript: 6.0.3
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@3.19.3(magicast@0.3.5))(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@3.19.3(magicast@0.5.2))(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -14345,7 +14373,7 @@ snapshots:
       vite: 7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4)
       vite-dev-rpc: 1.1.0(vite@7.3.6(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.46.0)(yaml@2.8.4))
     optionalDependencies:
-      '@nuxt/kit': 3.19.3(magicast@0.3.5)
+      '@nuxt/kit': 3.19.3(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Closes #107.

lightGallery is dual-licensed: free for open source, but "if you are using the library for business, commercial sites, projects, and applications, the Commercial license is the appropriate license". Without a key it logs `lightGallery: 0000-0000-000-0000 license key is not valid for production use`, and the key could not be set through this controller anyway — that is what [stimulus-lightbox#2](https://github.com/stimulus-components/stimulus-lightbox/issues/2) reported. [PhotoSwipe](https://photoswipe.com/) is MIT, has no dependencies, and needs no key.

## The controller

`PhotoSwipeLightbox` is built on `connect()` and destroyed on `disconnect()`. Options are merged in this order:

```js
{
  children: "a",
  pswpModule: PhotoSwipe,
  ...this.defaultOptions,
  ...this.optionsValue,
  gallery: this.element,
}
```

So `children` and `pswpModule` stay overridable — `pswpModule: () => import("photoswipe")` loads the core on the first click instead of upfront — while `gallery` is always the controller element. A subclass that replaces `defaultOptions` with `{}`, as the docs suggest, still gets a working gallery.

The instance is exposed as `this.photoSwipe`.

## Breaking changes

A **major** bump, recorded in `.changeset/lightbox-photoswipe.md`:

- Import `photoswipe/style.css` instead of `lightgallery/css/lightgallery.css`.
- Add `data-pswp-width` and `data-pswp-height` to every link of the gallery. PhotoSwipe needs the size of the full resolution image to open it without a layout shift.
- Rewrite `data-lightbox-options-value` with the [PhotoSwipe options](https://photoswipe.com/options/). No lightGallery option carries over as is.
- Read the instance from `this.photoSwipe` instead of `this.lightGallery`.

The docs page gets a "Migrating from v4" section covering all four.

## Also in here

- `photoswipe ^5.4.4` replaces `lightgallery` in the package, plus the Vite externals and UMD globals (`PhotoSwipe`, `PhotoSwipeLightbox`, which match what PhotoSwipe's own UMD builds expose).
- The local playground and the docs demo use the new markup and stylesheet.
- New `components/lightbox/spec/index.test.ts`: gallery binding, option merge, `gallery` not overridable, destroy on disconnect.

## Verified

`pnpm run lint`, `pnpm run test` (158 tests, 23 files), `pnpm run build:components`, and `pnpm -C docs generate` all pass.

Not verified: I have no browser here, so the lightbox was never actually clicked open. Worth a pass with `pnpm -C components/lightbox dev` before merging.

Co-Authored-By: Claude Code <noreply@anthropic.com>
