### PR TITLE
Add history navigation support to scroll-to

### DIFF
--- a/.changeset/scroll-to-history.md
+++ b/.changeset/scroll-to-history.md
@@ -1,0 +1,5 @@
+---
+"@stimulus-components/scroll-to": minor
+---
+
+Push the target hash into the URL and react to browser back/forward when the `history` option is enabled.

--- a/components/scroll-to/CHANGELOG.md
+++ b/components/scroll-to/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Push the target hash into the URL and react to browser back/forward when the `history` option is enabled.
+
 ## [5.0.1] - 2024-03-23
 
 ### Chore

--- a/components/scroll-to/index.html
+++ b/components/scroll-to/index.html
@@ -19,20 +19,45 @@
   <body>
     <div class="relative h-full max-w-5xl mx-auto px-4">
       <section class="mt-16 text-center">
-        <a href="#awesome-stuff-here" class="text-blue-500" data-controller="scroll-to" data-scroll-to-offset-value="50"
-          >Scroll to #awesome-stuff-here</a
+        <a
+          href="#first-target"
+          class="text-blue-500"
+          data-controller="scroll-to"
+          data-scroll-to-offset-value="50"
+          data-scroll-to-history-value="true"
         >
+          Scroll to #first-target
+        </a>
 
         <div class="h-screen"></div>
 
-        <h2 id="awesome-stuff-here" class="text-2xl">Awesome stuff here</h2>
-        <p>Keep scrolling 👇</p>
+        <h2 id="first-target" class="text-2xl">First target</h2>
+        <p class="mb-8">Keep scrolling 👇</p>
+
+        <a
+          href="#second-target"
+          class="text-blue-500"
+          data-controller="scroll-to"
+          data-scroll-to-offset-value="50"
+          data-scroll-to-history-value="true"
+        >
+          Scroll to #second-target
+        </a>
 
         <div class="h-screen"></div>
 
-        <a href="#awesome-stuff-here" class="text-blue-500" data-controller="scroll-to" data-scroll-to-offset-value="50"
-          >Scroll to #awesome-stuff-here</a
+        <h2 id="second-target" class="text-2xl">Second target</h2>
+        <p class="mb-8">Go back up 👆</p>
+
+        <a
+          href="#first-target"
+          class="text-blue-500"
+          data-controller="scroll-to"
+          data-scroll-to-offset-value="50"
+          data-scroll-to-history-value="true"
         >
+          Scroll back to #first-target
+        </a>
       </section>
     </div>
   </body>

--- a/components/scroll-to/spec/index.test.ts
+++ b/components/scroll-to/spec/index.test.ts
@@ -22,11 +22,21 @@ const stubScrollTo = (): void => {
   vi.stubGlobal("scrollTo", scrollTo)
 }
 
+// jsdom implements history.pushState; spy on it to observe calls without
+// mutating the URL mid-test.
+const stubPushState = (): void => {
+  vi.spyOn(window.history, "pushState").mockImplementation((): void => {})
+}
+
 // Stimulus connects controllers from a MutationObserver callback, so markup
 // assigned inside a test body is not live until the microtask queue drains.
 const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
 
-afterEach((): void => {
+afterEach(async (): Promise<void> => {
+  // Application.stop() does not disconnect connected controllers, so clear the
+  // DOM and drain the observer before stopping to release window listeners.
+  document.body.innerHTML = ""
+  await flush()
   application.stop()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
@@ -34,6 +44,7 @@ afterEach((): void => {
 
 beforeEach((): void => {
   stubScrollTo()
+  stubPushState()
   startStimulus()
 
   document.body.innerHTML = `
@@ -68,6 +79,12 @@ describe("#scroll", () => {
 
     // 100 below the fold, 300 already scrolled, less the default 10 offset.
     expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 390 }))
+  })
+
+  it("does not push the hash into the URL by default", (): void => {
+    link().click()
+
+    expect(window.history.pushState).not.toHaveBeenCalled()
   })
 })
 
@@ -132,6 +149,57 @@ describe("behavior value", () => {
   })
 })
 
+describe("history value", () => {
+  describe("when enabled", () => {
+    beforeEach((): void => {
+      document.body.innerHTML = `
+        <a id="link" href="#target" data-controller="scroll-to" data-scroll-to-history-value="true">Scroll</a>
+        <h2 id="target">Target</h2>
+      `
+    })
+
+    it("stores the target hash in the URL", (): void => {
+      link().click()
+
+      expect(window.history.pushState).toHaveBeenCalledWith(null, "", "#target")
+    })
+  })
+
+  describe("when disabled explicitly", () => {
+    beforeEach((): void => {
+      document.body.innerHTML = `
+        <a id="link" href="#target" data-controller="scroll-to" data-scroll-to-history-value="false">Scroll</a>
+        <h2 id="target">Target</h2>
+      `
+    })
+
+    it("does not touch the URL", (): void => {
+      link().click()
+
+      expect(window.history.pushState).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when enabled but the target is missing", () => {
+    beforeEach((): void => {
+      document.body.innerHTML = `
+        <a id="link" href="#nope" data-controller="scroll-to" data-scroll-to-history-value="true">Scroll</a>
+      `
+    })
+
+    it("warns, does not scroll, and does not push the hash", (): void => {
+      const warn = vi.spyOn(console, "warn").mockImplementation((): void => {})
+
+      link().click()
+
+      expect(scrollTo).not.toHaveBeenCalled()
+      expect(window.history.pushState).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalledOnce()
+      expect(warn.mock.calls[0][0]).toContain('"nope"')
+    })
+  })
+})
+
 describe("when the hash matches no element", () => {
   beforeEach((): void => {
     document.body.innerHTML = `<a id="link" href="#nope" data-controller="scroll-to">Scroll</a>`
@@ -155,6 +223,58 @@ describe("#disconnect", () => {
     await flush()
 
     link().click()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+})
+
+describe("back/forward navigation", () => {
+  afterEach((): void => {
+    history.replaceState(null, "", location.href.replace(/#.*/, ""))
+  })
+
+  describe("when history is enabled", () => {
+    beforeEach((): void => {
+      document.body.innerHTML = `
+        <a id="link" href="#target" data-controller="scroll-to" data-scroll-to-history-value="true">Scroll</a>
+        <h2 id="target">Target</h2>
+      `
+    })
+
+    it("scrolls to the element matching the restored hash", (): void => {
+      window.history.replaceState(null, "", "#target")
+
+      window.dispatchEvent(new PopStateEvent("popstate"))
+
+      expect(scrollTo).toHaveBeenCalledWith({ top: -10, behavior: "auto" })
+    })
+
+    it("warns and does not scroll when the hash matches no element", (): void => {
+      const warn = vi.spyOn(console, "warn").mockImplementation((): void => {})
+      window.history.replaceState(null, "", "#nope")
+
+      window.dispatchEvent(new PopStateEvent("popstate"))
+
+      expect(scrollTo).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalledOnce()
+      expect(warn.mock.calls[0][0]).toContain('"nope"')
+    })
+
+    it("does nothing when the hash is empty", async (): Promise<void> => {
+      const warn = vi.spyOn(console, "warn").mockImplementation((): void => {})
+      await flush()
+
+      window.dispatchEvent(new PopStateEvent("popstate"))
+
+      expect(scrollTo).not.toHaveBeenCalled()
+      expect(warn).not.toHaveBeenCalled()
+    })
+  })
+
+  it("does not scroll when history is disabled", (): void => {
+    window.history.replaceState(null, "", "#target")
+
+    window.dispatchEvent(new PopStateEvent("popstate"))
 
     expect(scrollTo).not.toHaveBeenCalled()
   })

--- a/components/scroll-to/src/index.ts
+++ b/components/scroll-to/src/index.ts
@@ -4,6 +4,7 @@ interface Option {
   offset?: number
 
   behavior?: ScrollBehavior
+  history?: boolean
 }
 
 export default class ScrollTo extends Controller<HTMLAnchorElement> {
@@ -12,32 +13,68 @@ export default class ScrollTo extends Controller<HTMLAnchorElement> {
   declare behaviorValue: ScrollBehavior
   declare hasOffsetValue: boolean
 
+  declare historyValue: boolean
+  declare hasHistoryValue: boolean
+
   static values = {
     offset: Number,
     behavior: String,
+    history: Boolean,
   }
 
   initialize(): void {
     this.scroll = this.scroll.bind(this)
+    this.onPopState = this.onPopState.bind(this)
   }
 
   connect(): void {
     this.element.addEventListener("click", this.scroll)
+    if (this.history) {
+      window.addEventListener("popstate", this.onPopState)
+    }
   }
 
   disconnect(): void {
     this.element.removeEventListener("click", this.scroll)
+    window.removeEventListener("popstate", this.onPopState)
+  }
+
+  historyValueChanged(): void {
+    if (this.history) {
+      window.addEventListener("popstate", this.onPopState)
+    } else {
+      window.removeEventListener("popstate", this.onPopState)
+    }
   }
 
   scroll(event: Event): void {
     event.preventDefault()
 
     const id: string = this.element.hash.replace(/^#/, "")
+
+    if (this.scrollToElement(id, this.behavior) && this.history) {
+      const hash: string = `#${id}`
+      if (location.hash !== hash) {
+        history.pushState(null, "", hash)
+      }
+    }
+  }
+
+  onPopState(_event: PopStateEvent): void {
+    if (!this.history || !location.hash) {
+      return
+    }
+
+    const id: string = location.hash.replace(/^#/, "")
+    this.scrollToElement(id, "auto")
+  }
+
+  scrollToElement(id: string, behavior: ScrollBehavior): boolean {
     const target = document.getElementById(id)
 
     if (!target) {
       console.warn(`[@stimulus-components/scroll-to] The element with the id: "${id}" does not exist on the page.`)
-      return
+      return false
     }
 
     const elementPosition: number = target.getBoundingClientRect().top + window.scrollY
@@ -45,8 +82,10 @@ export default class ScrollTo extends Controller<HTMLAnchorElement> {
 
     window.scrollTo({
       top: offsetPosition,
-      behavior: this.behavior,
+      behavior,
     })
+
+    return true
   }
 
   get offset(): number {
@@ -63,6 +102,14 @@ export default class ScrollTo extends Controller<HTMLAnchorElement> {
 
   get behavior(): ScrollBehavior {
     return this.behaviorValue || this.defaultOptions.behavior || "smooth"
+  }
+
+  get history(): boolean {
+    if (this.hasHistoryValue) {
+      return this.historyValue
+    }
+
+    return this.defaultOptions.history ?? false
   }
 
   get defaultOptions(): Option {

--- a/docs/components/content/Demo/ScrollTo.vue
+++ b/docs/components/content/Demo/ScrollTo.vue
@@ -5,6 +5,7 @@
       href="#scroll-to-demo-bottom"
       data-controller="scroll-to"
       data-scroll-to-offset-value="100"
+      data-scroll-to-history-value="true"
       class="text-yellow-600"
     >
       Scroll down to the target &darr;
@@ -15,7 +16,13 @@
 
     <p id="scroll-to-demo-bottom" class="font-semibold">Here it is 🎉</p>
 
-    <a href="#scroll-to-demo-top" data-controller="scroll-to" data-scroll-to-offset-value="100" class="text-yellow-600">
+    <a
+      href="#scroll-to-demo-top"
+      data-controller="scroll-to"
+      data-scroll-to-offset-value="100"
+      data-scroll-to-history-value="true"
+      class="text-yellow-600"
+    >
       Scroll back up &uarr;
     </a>
   </Block>

--- a/docs/content/docs/stimulus-scroll-to.md
+++ b/docs/content/docs/stimulus-scroll-to.md
@@ -44,12 +44,31 @@ With options:
 
 ::
 
+With history:
+
+::code-block{tabName="app/views/index.html"}
+
+```html
+<a
+  href="#awesome-stuff-here"
+  data-controller="scroll-to"
+  data-scroll-to-history-value="true"
+>
+  Scroll to #awesome-stuff-here
+</a>
+
+<h2 id="awesome-stuff-here">Awesome stuff here</h2>
+```
+
+::
+
 ## Configuration
 
-| Attribute                       | Default  | Description                               | Optional |
-| ------------------------------- | -------- | ----------------------------------------- | -------- |
-| `data-scroll-to-offset-value`   | `10`     | Offset in pixels from top of the element. | ✅       |
-| `data-scroll-to-behavior-value` | `smooth` | The scroll behavior. `auto` or `smooth`.  | ✅       |
+| Attribute                         | Default  | Description                                                          | Optional |
+| --------------------------------- | -------- | -------------------------------------------------------------------- | -------- |
+| `data-scroll-to-offset-value`     | `10`     | Offset in pixels from top of the element.                            | ✅       |
+| `data-scroll-to-behavior-value`   | `smooth` | The scroll behavior. `auto` or `smooth`.                             | ✅       |
+| `data-scroll-to-history-value`    | `false`  | Push the target hash into the URL and scroll to it with the browser back/forward buttons. | ✅       |
 
 ## Extending Controller
 


### PR DESCRIPTION
Adds opt-in history navigation support to `@stimulus-components/scroll-to`.

When `data-scroll-to-history-value="true"` is set, clicking a scroll-to link now:

- scrolls to the target as before
- pushes the target hash into the URL with `history.pushState`
- allows browser back/forward navigation to scroll to restored hashes

The default behavior is unchanged: existing scroll-to links do not update the URL unless the new value is enabled.

## Changes

- Add `data-scroll-to-history-value`
- Push hash into browser history after a successful scroll
- Handle `popstate` for browser back/forward navigation
- Avoid duplicate history entries for the current hash
- Skip empty-hash popstate events
- Update scroll-to tests, docs, changelog, changeset, and demos
